### PR TITLE
fix: 版面改用彈性高度，修好手機篩選抽屜

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,14 +90,38 @@ CI 規則 10 守它（`<svg>` 直屬、不帶 transform、圖檔存在且解析�
 
 ## 踩過的坑
 
-### ⚠️ 寫死的版面偏移量咬過三次
+### ⚠️ 寫死的版面偏移量咬過四次
 
-`#branch-nav` 曾寫死 `top: 6rem` 假設工具列恆 3rem 高；`#tree-controls`／`#detail` 曾寫死
-`top: 3rem` 假設 nav 恆 48px 高（實際 50.59px，差 2.59px 造成右上角 1px 突出）。
+1. `#branch-nav` 寫死 `top: 6rem`，假設工具列恆 3rem 高。
+2. `#tree-controls`／`#detail` 寫死 `top: 3rem`，假設 nav 恆 48px 高（實際 50.59px，
+   差 2.59px 造成右上角 1px 突出）。
+3. 手機篩選抽屜 `translateY(-110%)`，假設「自身高度的 110%」一定蓋得過 `top: 3rem`。
+4. **（2026-08-19）** `#canvas-host` 寫死 `height: calc(100vh - 110px)`，而 nav ＋ footer
+   實際是 124.53（桌機）／165.47（手機）——每個尺寸多出 15–55px 的捲動，捲到底時 fixed 的
+   `#tree-controls` 與 nav 之間裂開一條縫。
 
-**現在都改成量實際高度**（`tree-canvas.ts` 量 nav 寫進 CSS 變數 `--nav-h`）。
+**現在的做法**：`body:has(#canvas-host)` 是 flex column，`<main>` `flex: 1`，
+`#canvas-host` 也 `flex: 1`，畫布自然吃掉剩餘空間，零偏移量。
+`--nav-h` 仍由 `tree-canvas.ts` 量 nav 寫進 CSS 變數（量的是文件座標 `rect.bottom + scrollY`，
+不是視窗座標——頁面可捲時 resize 會把它烤成負數）。
+
+⚠️ **`#tree` 必須是 `position: absolute; inset: 0`**，不能用 `width/height: 100%`：SVG 有內建
+長寬比（viewBox 2000×1700），`height: 100%` 在父層高度未定案時退回 auto，用寬度反推出一個
+內在高度（1280 寬 → 1088 高）把 `<main>` 撐開，版面又捲得動。
+⚠️ `main:has(#canvas-host)` 要加 `margin-inline: 0; width: 100%`：global.css 的
+`main { margin: 0 auto }` 在 flex 容器裡會**取消 stretch**，畫布會縮成 SVG 預設的 300px 寬。
+
 **動版面時不要再引入新的固定偏移量**，並且驗收要用**幾何斷言**（兩個矩形不相交、
-top 差距 < 0.5px），不是看截圖。
+top 差距 < 0.5px、`scrollHeight === innerHeight`），不是看截圖。
+E2E 的 U（不該捲動）、V（詳情卡片避開側欄）、J（手機抽屜不蓋住工具列）就是這三條防線。
+
+### 已知未修：手機版 `#branch-chips` 蓋住 footer
+
+`#branch-chips` 是 `position: fixed; bottom: 0`，頁面不捲動之後它永遠疊在 footer 上緣
+（實測 390×844：chips 791.75–844、footer 729.13–844）。要修得動整個手機底部區
+（`#detail` 是 `inset: auto 0 0 0` 的底部抽屜，靠 `padding-bottom: 4.5rem` 讓警告文字避開
+chips，而 chips 靠 DOM 順序畫在抽屜之上）——把 chips 放回文件流程會連帶改變抽屜的行為。
+這是設計決定不是 bug 修正，留待日後一併處理。
 
 ### 資料解析
 

--- a/src/pages/tree.astro
+++ b/src/pages/tree.astro
@@ -90,20 +90,62 @@ const TYPES: Array<[string, string]> = [
 
 <style is:global>
   /* 畫布頁不要吃到 Base.astro 版面預設的 <main> 內距／寬度上限，
-     其餘頁面（首頁、貢獻頁）維持原本的閱讀寬度不受影響。 */
+     其餘頁面（首頁、貢獻頁）維持原本的閱讀寬度不受影響。
+
+     ⚠️ 這一組（body / main / #canvas-host）是「畫布剛好填滿 nav 與 footer 之間」的**唯一**
+     機制，不要再往裡面加任何 px 偏移量。舊版寫的是 `height: calc(100vh - 110px)`，而 nav
+     實測 50.59 ＋ footer 114.88 ＝ 165.47（手機）／50.59 ＋ 73.94 ＝ 124.53（桌機）——
+     每個尺寸多出 15～55px 的捲動，捲到底時 fixed 的 #tree-controls 會跟 nav 之間裂開一條縫、
+     手機版 #branch-chips 壓在 footer 上。這是「寫死版面偏移量」在這個 repo 咬人的第四次
+     （前三次見 #tree-controls 那條規則的註解與 CLAUDE.md）。
+
+     改成讓 <main> 吃掉 nav 與 footer 之外的剩餘空間：
+     - min-height 用 100dvh（行動瀏覽器的網址列會伸縮，100vh 量的是「網址列收起時」的高度，
+       在網址列展開時會多出一截）；100vh 留一行當不支援 dvh 時的 fallback。
+     - main 的 `min-height: 0` 不能省：flex 子元素的預設 min-height 是 auto，SVG 會把 main
+       撐開到內容高度，剩餘空間就白算了。 */
+  body:has(#canvas-host) {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    min-height: 100dvh;
+  }
+
   main:has(#canvas-host) {
     max-width: none;
     padding: 0;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    /* global.css 的 `main { margin: 0 auto }` 是給內容頁置中用的。body 一旦變成 flex column，
+       水平方向的 auto 邊界會**取消 stretch**：main 不再撐滿寬度，而是縮到內容寬——裡面只有一張
+       沒有內建尺寸的 SVG，於是整個畫布縮成瀏覽器預設的 300px 寬。這兩行把它扳回來。 */
+    margin-inline: 0;
+    width: 100%;
   }
 
+  /* 用 flex: 1 而不是 height: 100%：百分比高度要求父層有「確定的」高度，而 main 的高度是
+     flex 算出來的，瀏覽器解析百分比時拿不到那個值（實測會縮成 255px）。讓 #canvas-host
+     自己也當 flex 子元素去分剩餘空間，就沒有百分比解析的問題。 */
   #canvas-host {
-    height: calc(100vh - 110px);
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     touch-action: none;
+    /* 給下面那張絕對定位的 SVG 當定位基準。 */
+    position: relative;
   }
 
+  /* ⚠️ 絕對定位、不是 width/height: 100%。
+     SVG 有內建的長寬比（viewBox 2000×1700），`height: 100%` 在父層高度還沒定案時會退回
+     auto，於是它用「寬度 ÷ 長寬比」算出一個內在高度（1280 寬 → 1088 高）反過來把 <main>
+     撐開——版面就又捲得動了，而且畫布比視窗還高。抽離普通流程後它對版面的高度貢獻是 0，
+     大小完全由 #canvas-host 決定。 */
   #tree {
     display: block;
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
   }
@@ -430,28 +472,25 @@ const TYPES: Array<[string, string]> = [
          蓋進 chip 列 787.75px 起點約 22px；加回後通過）。 */
       padding-bottom: 4.5rem;
     }
+    /* 手機版篩選抽屜：**留在 #toolbar 的正常流程裡**，收起就不存在、展開就接在工具列下面。
+       不用 position:fixed，也不用任何位移量。
+
+       舊版是 `position: fixed; top: 0` 收起、`transform: translateY(var(--nav-h))` 展開——
+       跟 #tree-controls 的 `top: var(--nav-h)` 用同一個基準，於是展開後抽屜**從工具列頭上
+       開始蓋**，把搜尋框和 #filters-toggle 自己都蓋住（實測 Pixel 7：抽屜 50.59–119.66、
+       切換鈕 58.59–97.38，elementFromPoint(切換鈕中心) 回傳 FIELDSET）。開了就關不掉，
+       唯一的出路是重新整理。用同一個變數並不能救——兩者本來就該是上下相接，不是同一個起點。
+
+       `display: none` 一併解掉另一個問題：收起狀態的 checkbox 以前仍然可以 Tab 聚焦、
+       螢幕閱讀器也仍然唸得到一個看不見的表單。 */
     #filters {
-      position: fixed;
-      /* 收起狀態用 top:0 + translateY(-100%)，不是 top:3rem + translateY(-110%)
-         （task-18 code review 找到的真實 bug：-110% 是面板「自身高度」的 110%，面板
-         裡有分支／類型兩個 fieldset，在窄螢幕上換行變高後，-110% 換算出來的位移量往往
-         不足以蓋過 top:3rem 這個已經在視窗內 48px 的錨點，導致面板最底下一排（類型）的
-         邊緣露出約 30-40px。改成 top:0 + translateY(-100%)：不管面板實際多高，
-         translateY(-100%) 永遠讓面板的底緣精確貼齊視窗頂端正上方（y=0），是跟內容高度
-         無關、恆成立的收起位置。 */
-      top: 0;
-      left: 0;
-      right: 0;
-      transform: translateY(-100%);
-      transition: transform 0.2s;
-      background: var(--panel);
+      display: none;
+      width: 100%;
+      flex-direction: column;
+      align-items: flex-start;
     }
     #filters.open {
-      /* 展開：滑到工具列（top: var(--nav-h, 3rem)，現在寫在 #tree-controls，見上面
-         該規則）下面，跟收起前的視覺位置一致。這裡跟 #tree-controls 用同一個變數，
-         不能各自硬寫一份數字——不然 #tree-controls 修好對齊 nav 之後，這裡沒跟著改
-         就會重新製造出同一種「兩個地方各自假設同一個高度、實際不同步」的落差。 */
-      transform: translateY(var(--nav-h, 3rem));
+      display: flex;
     }
     #branch-chips {
       position: fixed;

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -37,7 +37,13 @@ const byId = new Map(data.nodes.map(n => [n.id, n]));
 function updateNavHeight(): void {
   const nav = document.getElementById('site-nav');
   if (!nav) return;
-  const bottom = nav.getBoundingClientRect().bottom;
+  // ⚠️ 量的是**文件座標**（offsetTop + offsetHeight），不是 getBoundingClientRect().bottom。
+  // 後者是視窗座標：頁面只要能捲動，捲到 y=100 時 resize 一次，--nav-h 就會被寫成
+  // 「nav 高度 − 100」甚至負數，#tree-controls 與 #detail 跟著跳到 nav 上面去。
+  // 版面改成 flex 之後畫布頁本來就不該捲得動，這條是保險。
+  // getBoundingClientRect() 保留次像素（nav 實測 50.59px，offsetHeight 會四捨五入成 51），
+  // 再補回 scrollY 換算成文件座標。
+  const bottom = nav.getBoundingClientRect().bottom + window.scrollY;
   // 單元測試環境（linkedom）沒有版面引擎，getBoundingClientRect() 預設全 0，
   // bottom <= 0 一定不是真實渲染結果，跳過寫入、讓 CSS 的 3rem fallback 留著
   // （tests/scripts/tree-canvas.test.ts 的頁面 fixture 也沒有 #site-nav，上面
@@ -397,6 +403,16 @@ function positionPanel(): void {
     ? toolbarEl.getBoundingClientRect().bottom
     : parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--nav-h')) || 48;
 
+  // 左緣還要避開 #branch-nav 側欄。只避 #toolbar 是不夠的：側欄比工具列矮但更長，760px 寬時
+  // 卡片會被夾到 left=12，正好壓在側欄按鈕上並攔截點擊（實測 760×800：#detail 12–364 /
+  // 158.91–549.28，#branch-nav 0–79.19 / 146.91–356.75，兩個矩形相交）。
+  //
+  // ⚠️ 量的是 #branch-nav 不是它的父層 #tree-controls：後者是 flex column，盒子會撐到最寬
+  // 子元素（#toolbar）的寬度，右邊一大片是 pointer-events:none 的透明空白（見 tree.astro
+  // 那條規則的註解）。拿它當障礙物會把卡片推到畫面外（實測 1280 寬下 left 被推到 1001，
+  // 卡片右緣 1353 超出視窗）。
+  const obstacle = document.getElementById('branch-nav')?.getBoundingClientRect() ?? null;
+
   // 高度上限也要從同一個基準算。CSS 的 max-height 是用 --nav-h 起算的，但實際起點是工具列
   // 下緣（低了約 68px），兩邊基準不一致時面板下緣會超出視窗——而面板最後一段固定是 spec
   // §2.1 強制要求的「重置需要初期化券」災情警告，捲到底也看不到（code review 實測 1000×480
@@ -407,15 +423,24 @@ function positionPanel(): void {
   const rect = panel.getBoundingClientRect();
   const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(v, hi));
 
-  let left = n.right + GAP;
-  if (left + rect.width > window.innerWidth - GAP) left = n.left - GAP - rect.width;
-  left = clamp(left, GAP, Math.max(GAP, window.innerWidth - rect.width - GAP));
-
   const top = clamp(
     n.top + n.height / 2 - rect.height / 2,
     topLimit + GAP,
     Math.max(topLimit + GAP, window.innerHeight - rect.height - GAP),
   );
+
+  // 只有當卡片的垂直範圍真的跟側欄重疊時才把左緣往右推——卡片落在側欄下方時沒必要浪費那段寬度。
+  // 側欄在手機版是 display:none（width 0），那時也不必推。
+  const overlapsSidebar = !!obstacle && obstacle.width > 0
+    && top < obstacle.bottom && top + rect.height > obstacle.top;
+  const rightLimit = Math.max(GAP, window.innerWidth - rect.width - GAP);
+  // 下限取 min(避障後的左界, 右界)：視窗窄到「避開側欄就一定超出畫面」時，寧可重疊也不要
+  // 把卡片推出視窗——看不到比被壓住更糟。
+  const leftLimit = Math.min(overlapsSidebar ? Math.max(GAP, obstacle!.right + GAP) : GAP, rightLimit);
+
+  let left = n.right + GAP;
+  if (left + rect.width > window.innerWidth - GAP) left = n.left - GAP - rect.width;
+  left = clamp(left, leftLimit, rightLimit);
 
   panel.style.left = `${left}px`;
   panel.style.top = `${top}px`;
@@ -600,16 +625,43 @@ const searchEl = document.getElementById('search');
 if (!(searchEl instanceof HTMLInputElement)) {
   throw new Error('找不到 #search，搜尋功能無法掛載');
 }
-const filtersEl = document.getElementById('filters');
-if (!filtersEl) {
+const filtersElOrNull = document.getElementById('filters');
+if (!filtersElOrNull) {
   throw new Error('找不到 #filters，篩選功能無法掛載');
 }
+// 收窄後的別名：TypeScript 的 narrowing 不會跟著進到下面那些回呼／函式裡。
+const filtersEl: HTMLElement = filtersElOrNull;
 
 // --- 手機版篩選抽屜（task-17）：#filters 預設收起（見 tree.astro 的手機媒體查詢），
 // 點 #filters-toggle 切換展開/收起。桌機版沒有這顆按鈕（CSS 隱藏），這裡用 optional
 // chaining 讓「找不到這個按鈕」不算錯誤——它本來就只在手機版版面才存在。
-document.getElementById('filters-toggle')?.addEventListener('click', () => {
-  filtersEl.classList.toggle('open');
+const filtersToggle = document.getElementById('filters-toggle');
+
+/** 開關抽屜，並把狀態同步到 aria——按鈕的 aria-label 以前永遠是「展開篩選」，也沒有 aria-expanded。 */
+function setFiltersOpen(open: boolean): void {
+  filtersEl.classList.toggle('open', open);
+  filtersToggle?.setAttribute('aria-expanded', String(open));
+  filtersToggle?.setAttribute('aria-label', open ? '收起篩選' : '展開篩選');
+}
+setFiltersOpen(false);
+
+filtersToggle?.addEventListener('click', () => {
+  setFiltersOpen(!filtersEl.classList.contains('open'));
+});
+
+// 抽屜要有出路。舊版展開後會蓋住自己的切換鈕，而且沒有 Esc、沒有點外面關閉——唯一的辦法是
+// 重新整理。版面修好之後切換鈕不再被蓋住，這兩條是額外的出口（也是一般抽屜該有的行為）。
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && filtersEl.classList.contains('open')) {
+    setFiltersOpen(false);
+    filtersToggle?.focus();
+  }
+});
+document.addEventListener('pointerdown', e => {
+  if (!filtersEl.classList.contains('open')) return;
+  const t = e.target as Node | null;
+  if (t && (filtersEl.contains(t) || filtersToggle?.contains(t))) return;
+  setFiltersOpen(false);
 });
 
 // --- 關鍵字 chip 可點擊搜尋（spec §6.2.3，task-17 補漏）---

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -485,15 +485,108 @@ test('I. 初次載入未經任何互動，只要初始縮放超過 1x，可見�
   expect(fill).toMatch(/^url\(#icon-hires-[0-9a-f]+\)$/);
 });
 
-test('J. 手機版收起的篩選抽屜完全滑出畫面，不再露出一截', async ({ page, isMobile }) => {
-  test.skip(!isMobile, '僅手機版：篩選抽屜收合行為只在手機版存在');
+test('J. 手機版篩選抽屜：展開後不蓋住工具列，而且關得掉', async ({ page, isMobile }) => {
+  test.skip(!isMobile, '僅手機版：篩選抽屜只在手機版存在');
   await page.goto('/tree');
-  const box = await page.locator('#filters').boundingBox();
-  if (!box) throw new Error('#filters 沒有 bounding box');
-  // 收起狀態下，面板的「底緣」（y + height）應該落在視窗頂端（y=0）或更上面，完全看不到；
-  // 舊 bug（top:3rem + translateY(-110%)）在面板換行變高後，底緣會落在 y≈30-40px，
-  // 露出最後一排 checkbox。
-  expect(box.y + box.height).toBeLessThanOrEqual(1); // 留 1px 容錯給次像素捨入
+
+  const filters = page.locator('#filters');
+  const toggle = page.locator('#filters-toggle');
+  const search = page.locator('#search');
+
+  // 收起狀態：整個不存在於版面上（display:none）。這同時解掉「看不見卻仍可 Tab 聚焦、
+  // 螢幕閱讀器仍唸得到」的問題——舊版是 transform 移出畫面，元素還在。
+  await expect(filters).toBeHidden();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('#filters input[type=checkbox]').first()).toBeHidden();
+
+  await toggle.click();
+  await expect(filters).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+  // 核心斷言：抽屜與工具列上的兩個東西都不相交。
+  // 舊 bug 是 `#filters.open { transform: translateY(var(--nav-h)) }` 跟
+  // `#tree-controls { top: var(--nav-h) }` 用同一個基準，抽屜從工具列**頭上**開始蓋，
+  // 把搜尋框和切換鈕自己都蓋住（實測 Pixel 7：抽屜 50.59–119.66、切換鈕 58.59–97.38）。
+  const [f, t, se] = await Promise.all([filters.boundingBox(), toggle.boundingBox(), search.boundingBox()]);
+  if (!f || !t || !se) throw new Error('取不到 bounding box');
+  const disjoint = (a: typeof f, b: typeof f) =>
+    a.x + a.width <= b.x + 0.5 || b.x + b.width <= a.x + 0.5 ||
+    a.y + a.height <= b.y + 0.5 || b.y + b.height <= a.y + 0.5;
+  expect(disjoint(f, t), '抽屜不可與切換鈕相交').toBe(true);
+  expect(disjoint(f, se), '抽屜不可與搜尋框相交').toBe(true);
+
+  // 切換鈕真的點得到（矩形不相交還不夠——中間可能隔著別的透明疊層）。
+  const hit = await page.evaluate(() => {
+    const r = document.querySelector('#filters-toggle')!.getBoundingClientRect();
+    return document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2)?.id ?? null;
+  });
+  expect(hit).toBe('filters-toggle');
+
+  // 關得掉：再點一次（Playwright 的 actionability 檢查本身就會抓到「被蓋住」）。
+  await toggle.click();
+  await expect(filters).toBeHidden();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+  // Esc 也是出路。
+  await toggle.click();
+  await expect(filters).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(filters).toBeHidden();
+});
+
+test('U. 畫布頁不該捲動：畫布剛好填滿 nav 與 footer 之間', async ({ page }) => {
+  // 舊 bug：`#canvas-host { height: calc(100vh - 110px) }`，而 nav ＋ footer 實測是
+  // 124.53（桌機）／165.47（手機），每個尺寸多出 15–55px 的捲動；捲到底時 fixed 的
+  // #tree-controls 會跟 nav 之間裂開一條縫。這是「寫死版面偏移量」在這個 repo 的第四次。
+  for (const [w, h] of [[390, 844], [768, 1024], [1280, 720]] as const) {
+    await page.setViewportSize({ width: w, height: h });
+    await page.goto('/tree');
+    await page.waitForSelector('#tree g.node');
+
+    const m = await page.evaluate(() => {
+      const nav = document.querySelector('#site-nav')!.getBoundingClientRect();
+      const ctl = document.querySelector('#tree-controls')!.getBoundingClientRect();
+      const host = document.querySelector('#canvas-host')!.getBoundingClientRect();
+      return {
+        overflow: document.documentElement.scrollHeight - window.innerHeight,
+        gap: ctl.top - nav.bottom,
+        hostWidth: host.width,
+        hostHeight: host.height,
+      };
+    });
+    expect(m.overflow, `${w}x${h} 不該捲得動`).toBeLessThanOrEqual(0);
+    expect(Math.abs(m.gap), `${w}x${h} 工具列要貼齊 nav 下緣`).toBeLessThan(0.5);
+    // 順帶釘住「畫布真的有填滿」：SVG 有內建長寬比，用百分比高度會縮成 300px 寬（實測）。
+    expect(m.hostWidth, `${w}x${h} 畫布寬度`).toBeCloseTo(w, 0);
+    expect(m.hostHeight, `${w}x${h} 畫布高度`).toBeGreaterThan(h * 0.5);
+  }
+});
+
+test('V. 窄桌機視窗下詳情卡片不壓在分支側欄上，也不被推出畫面', async ({ page, isMobile }) => {
+  test.skip(isMobile, '僅桌機版：#branch-nav 側欄在手機版是 display:none');
+  // 舊 bug：positionPanel() 只避 #toolbar 不避 #branch-nav，760px 寬時卡片被夾到 left=12，
+  // 正好壓在側欄按鈕上並攔截點擊（實測 #detail 12–364、#branch-nav 0–79.19，垂直也相交）。
+  // 修法量的是 #branch-nav 本身，不是它的父層 #tree-controls——後者的盒子會撐到最寬子元素
+  // 的寬度，右邊一大片是 pointer-events:none 的透明空白，拿它當障礙物會把卡片推出畫面
+  // （實測 1280 寬下 left 被推到 1001、右緣 1353）。
+  for (const [w, h] of [[760, 800], [1280, 720]] as const) {
+    await page.setViewportSize({ width: w, height: h });
+    await page.goto('/tree?node=1001');
+    await page.waitForSelector('#tree g.node');
+    await expect(page.locator('#detail')).toBeVisible();
+
+    const m = await page.evaluate(() => {
+      const d = document.querySelector('#detail')!.getBoundingClientRect();
+      const b = document.querySelector('#branch-nav')!.getBoundingClientRect();
+      return {
+        intersects: d.left < b.right && d.right > b.left && d.top < b.bottom && d.bottom > b.top,
+        left: d.left, right: d.right,
+      };
+    });
+    expect(m.intersects, `${w}x${h} 詳情卡片不可與分支側欄相交`).toBe(false);
+    expect(m.left, `${w}x${h} 卡片左緣不可跑出畫面`).toBeGreaterThanOrEqual(0);
+    expect(m.right, `${w}x${h} 卡片右緣不可跑出畫面`).toBeLessThanOrEqual(w);
+  }
 });
 
 test('K. 手機版詳情面板的重置警告不被底部分支 chip 蓋住（spec §2.1 強制要求的災情警告）', async ({ page, isMobile }) => {

--- a/tests/scripts/tree-canvas.test.ts
+++ b/tests/scripts/tree-canvas.test.ts
@@ -279,14 +279,21 @@ describe('tree-canvas 整合：分支快速跳轉（task-17，spec §6.2.6）', 
 
   // task-18 第二輪修正：可讀性下限不再是手機專屬，桌機也會套用（見
   // src/scripts/tree-canvas.ts 的 applyReadabilityFloor() 說明）。桌機測試因此也要掛一個
-  // 真實桌機容器尺寸的 getBoundingClientRect stub（1280x610，跟真實 Desktop Chrome 預設
-  // 視窗實測值一致——1280 寬減不出來，610 是視窗高度 720 扣掉 #canvas-host 的
-  // `calc(100vh - 110px)` 那個 110），不然 linkedom 預設的全 0 版面資訊會讓下限退化成
-  // Infinity、被 Viewport 的硬上限夾到 8（跟下面手機測試「環境限制記錄」那條是同一類
-  // 退化路徑，但這裡的重點是驗證桌機的正常路徑，不是記錄環境限制，所以要掛 stub 避開它）。
+  // 真實桌機容器尺寸的 getBoundingClientRect stub，不然 linkedom 預設的全 0 版面資訊會讓
+  // 下限退化成 Infinity、被 Viewport 的硬上限夾到 8（跟下面手機測試「環境限制記錄」那條是
+  // 同一類退化路徑，但這裡的重點是驗證桌機的正常路徑，不是記錄環境限制，所以要掛 stub 避開它）。
+  //
+  // 1280×595 取自 Playwright Desktop Chrome（1280×720）下的實測值：#canvas-host 是 flex
+  // 子元素，吃掉 nav（50.59）與 footer（73.94）之外的剩餘高度。**這裡不要再自己算一個
+  // `視窗高 − 某個常數`**：舊註解寫的 610 是從 `calc(100vh - 110px)` 那個寫死偏移量推來的，
+  // 而那個 110 本身就是錯的（實際 124.53），版面改成 flex 之後那條 CSS 已經不存在了。
+  const DESKTOP_CANVAS_HEIGHT = 595;
   function stubDesktopRect(page: { svg: HTMLElement }): void {
     Object.assign(page.svg, {
-      getBoundingClientRect: () => ({ x: 0, y: 0, left: 0, top: 0, right: 1280, bottom: 610, width: 1280, height: 610 }),
+      getBoundingClientRect: () => ({
+        x: 0, y: 0, left: 0, top: 0,
+        right: 1280, bottom: DESKTOP_CANVAS_HEIGHT, width: 1280, height: DESKTOP_CANVAS_HEIGHT,
+      }),
     });
   }
 


### PR DESCRIPTION
review 報告的 **P4（手機篩選抽屜）＋ P5（版面偏移量）**。兩包一起做，因為都改 `tree.astro` 的版面。

改動前先用 Playwright 量出基準，三個回報的 bug 全部重現：

```
=== mobile-390 (390x844) ===
  scrollHeight 899 / innerHeight 844 → 多出 55 px          ← P5
  展開 #filters  { top: 50.59, bottom: 119.66 }
  #filters-toggle { top: 58.59, bottom: 97.38 }            ← 抽屜從工具列頭上開始蓋
  切換鈕中心點到的是： FIELDSET ❌ 被蓋住                     ← P4：開了就關不掉
=== narrow-760 (760x800) ===
  #detail    12–364 / 158.91–549.28
  #branch-nav 0–79.19 / 146.91–356.75  ❌ 相交               ← F-canvas-5
```

## P5：畫布高度改成彈性版面

`#canvas-host { height: calc(100vh - 110px) }` 是「寫死版面偏移量」在這個 repo 咬人的**第四次**（前三次見 CLAUDE.md）。nav ＋ footer 實際是 124.53（桌機）／165.47（手機）。

改成 `body:has(#canvas-host)` flex column → `<main> flex: 1` → `#canvas-host flex: 1`，畫布自然吃掉剩餘空間，零偏移量。過程中踩到兩個非顯而易見的坑，都寫進註解與 CLAUDE.md：

- **`#tree` 必須 `position: absolute; inset: 0`**，不能用 `height: 100%`：SVG 有內建長寬比（viewBox 2000×1700），父層高度未定案時 `height: 100%` 退回 auto，用寬度反推出內在高度（1280 寬 → 1088 高）把 `<main>` 撐開，版面又捲得動。
- **`main:has(#canvas-host)` 要加 `margin-inline: 0; width: 100%`**：global.css 的 `main { margin: 0 auto }` 在 flex 容器裡會**取消 stretch**，畫布縮成 SVG 預設的 300px 寬（實測）。

另外兩處：
- `--nav-h` 改量文件座標（`rect.bottom + scrollY`），不是視窗座標——頁面可捲時 resize 會把它烤成負數
- `positionPanel()` 左緣避開 **`#branch-nav`**（不是它的父層 `#tree-controls`——後者的盒子會撐到最寬子元素的寬度，右邊一大片是 `pointer-events: none` 的透明空白，拿它當障礙物會把卡片推出畫面：實測 1280 寬下 left 被推到 1001、右緣 1353）

## P4：抽屜留在流程裡

舊版 `position: fixed` ＋ `transform: translateY(var(--nav-h))`，跟 `#tree-controls { top: var(--nav-h) }` 用同一個基準——所以抽屜從工具列**頭上**開始蓋，把搜尋框和切換鈕自己都蓋住。用同一個變數並不能救：兩者本來就該上下相接，不是同一個起點。

改成 `display: none` / `.open { display: flex }`，留在 `#toolbar` 的正常流程裡，展開就接在工具列下面。零測量、零位移量。順帶解掉「收起狀態的 checkbox 仍可 Tab 聚焦、螢幕閱讀器仍唸得到」。

再補：Esc 關閉、點抽屜外關閉、`aria-expanded` 與 `aria-label` 隨狀態同步（以前永遠是「展開篩選」）。

## 改動後

```
1280x720 { host: [1280, 595.5], 捲動溢出: 0, ctl-nav差: 0 }
768x1024 { host: [768, 899.5],  捲動溢出: 0, ctl-nav差: 0 }
390x844  { host: [390, 678.5],  捲動溢出: 0, ctl-nav差: 0 }
760x800  { host: [760, 675.5],  捲動溢出: 0, ctl-nav差: 0 }

展開 #filters { top: 109.38 }（工具列下緣 97.38 之下）
切換鈕中心點到的是： filters-toggle ✅
760×800  #detail 91.19–443.19 vs #branch-nav 0–79.19 ✅ 不相交
1280×720 #detail 665–1017，未超出視窗 ✅
```

## 測試

- **J 改寫**：`display: none` 之後 `boundingBox()` 是 null，舊斷言會 throw（報告已預告）。新版驗的是更強的性質：收起時 hidden 且 checkbox 不可聚焦、展開後與切換鈕／搜尋框兩兩不相交、`elementFromPoint(切換鈕中心)` 就是切換鈕本身、再點一次能關、Esc 能關、`aria-expanded` 同步。
- **U 新增**：390／768／1280 三個尺寸 `scrollHeight <= innerHeight`、`|#tree-controls.top − #site-nav.bottom| < 0.5`、畫布寬高真的填滿。
- **V 新增**：760×800 與 1280×720 下 `#detail` 與 `#branch-nav` 不相交，且不超出視窗。
- `tests/scripts/tree-canvas.test.ts` 裡抄自 `calc(100vh - 110px)` 的 610 魔數改成有來源說明的實測值。

```
npm run validate  ✅ ／ npm run typecheck ✅ ／ npm test ✅ 273
npm run e2e       ✅ 54 passed / 8 skipped（先前 51/7）
```

弄壞會不會紅：畫布高度改回 `calc(100vh - 110px)` → U 紅；`positionPanel` 不避側欄 → V 紅；抽屜改回 fixed+translateY → J 紅。

## ⚠️ 一條驗收沒做到

報告的 P5 驗收裡有「`#branch-chips` 與 footer 不相交」，**這條沒有做**。頁面不再捲動之後，`position: fixed; bottom: 0` 的 chips 永遠疊在 footer 上緣（390×844：chips 791.75–844、footer 729.13–844）。

要修得動整個手機底部區：`#detail` 是 `inset: auto 0 0 0` 的底部抽屜，靠 `padding-bottom: 4.5rem` 讓 spec §2.1 的災情警告避開 chips，而 chips 靠 DOM 順序畫在抽屜之上。把 chips 放回文件流程會連帶改變抽屜行為與那個 padding 的基準——那是設計決定不是 bug 修正。已記在 CLAUDE.md 的「已知未修」。
