### PR TITLE
fix: 高解析圖示門檻改用裝置像素

### DIFF
--- a/src/lib/hires.ts
+++ b/src/lib/hires.ts
@@ -48,7 +48,46 @@ function hiresPatternId(icon: string): string {
  * 用 `icon.dataset.hires === '1'` 記錄「已經升級過」，避免同一個節點被重複處理（例如使用者
  * 反覆縮放、同一個節點多次落在可視範圍內）時重複改寫 DOM。
  */
-export function upgradeIcons(ids: string[], svg: SVGSVGElement, base = '/assets/icons'): void {
+/**
+ * 一次把 `g.node[data-id] > rect.icon` 全部索引起來，供 `upgradeIcons()` 重複使用。
+ *
+ * 沒有它的話，每次縮放（rAF 節流後仍然是每幾個影格一次）都要對每個可見節點各跑一次
+ * `svg.querySelector('g.node[data-id="…"] > rect.icon')`。節點是建置期一次畫好、之後不再
+ * 增刪的，索引建一次就永遠有效。
+ */
+export function buildIconIndex(svg: SVGSVGElement): Map<string, SVGRectElement> {
+  const index = new Map<string, SVGRectElement>();
+  for (const icon of svg.querySelectorAll<SVGRectElement>('g.node > rect.icon')) {
+    const id = (icon.parentElement as Element | null)?.getAttribute('data-id');
+    if (id) index.set(id, icon);
+  }
+  return index;
+}
+
+/**
+ * 把圖示換回共用的 sprite。
+ *
+ * 兩個用途：①縮小到不再需要 2× 素材時回收（見 tree-canvas.ts 的遲滯門檻）；
+ * ②高解析 WebP 載入失敗時止血——沒有這條的話，`<pattern>` 裡是一張永遠載不到的
+ * `<image>`，貼上去的 `<rect>` 就是一塊什麼都沒有的空白，畫面上是一個「破圖」節點，
+ * 而且沒有任何錯誤訊息。
+ */
+export function downgradeIcons(icons: Iterable<SVGRectElement>): void {
+  for (const icon of icons) {
+    if (icon.dataset.hires !== '1') continue;
+    const sprite = icon.dataset.spriteFill;
+    if (!sprite) continue;
+    icon.setAttribute('fill', sprite);
+    delete icon.dataset.hires;
+  }
+}
+
+export function upgradeIcons(
+  ids: string[],
+  svg: SVGSVGElement,
+  base = '/assets/icons',
+  index?: Map<string, SVGRectElement>,
+): void {
   const doc = svg.ownerDocument;
   // render.ts 現在一定會建立 <defs>（不管有沒有圖示都會），這裡直接假設它存在、找不到就是
   // 呼叫端傳了一個不是 renderTree() 產生的 svg，用法錯誤，不需要再防禦性地自己建一個。
@@ -61,7 +100,7 @@ export function upgradeIcons(ids: string[], svg: SVGSVGElement, base = '/assets/
   const patternedThisCall = new Set<string>();
 
   for (const id of ids) {
-    const icon = svg.querySelector<SVGRectElement>(`g.node[data-id="${id}"] > rect.icon`);
+    const icon = index?.get(id) ?? svg.querySelector<SVGRectElement>(`g.node[data-id="${id}"] > rect.icon`);
     if (!icon || icon.dataset.hires === '1') continue;
 
     const hash = icon.getAttribute('data-icon');
@@ -96,11 +135,24 @@ export function upgradeIcons(ids: string[], svg: SVGSVGElement, base = '/assets/
       img.setAttribute('href', `${base}/${hash}.webp`);
       img.setAttribute('width', w);
       img.setAttribute('height', h);
+      // 載入失敗（檔案被刪、雜湊改了沒重建、CDN 出問題）時把用到這個 pattern 的節點全部
+      // 換回 sprite，並把 pattern 移除，免得後面的節點又貼上同一個壞掉的圖案。
+      // 不做這件事的話，畫面上就是一個空白的節點，而且沒有任何錯誤訊息。
+      img.addEventListener('error', () => {
+        const affected = [...svg.querySelectorAll<SVGRectElement>(`rect.icon[data-icon="${hash}"]`)];
+        downgradeIcons(affected);
+        pattern.remove();
+      });
       pattern.appendChild(img);
       defs.appendChild(pattern);
     }
     patternedThisCall.add(hash);
 
+    // 記下原本的 sprite fill，降級時要換回來（縮小回門檻以下、或高解析圖載入失敗）。
+    if (!icon.dataset.spriteFill) {
+      const current = icon.getAttribute('fill');
+      if (current) icon.dataset.spriteFill = current;
+    }
     icon.setAttribute('fill', `url(#${patId})`);
     icon.dataset.hires = '1';
   }

--- a/src/lib/viewport.ts
+++ b/src/lib/viewport.ts
@@ -56,6 +56,47 @@ const MAX = 8;
 export const DESKTOP_ICON_TARGET_PX = 26;
 export const MOBILE_ICON_TARGET_PX = 35;
 
+/**
+ * 升級成高解析圖示的門檻（單位：**裝置像素 / 使用者座標單位**）。
+ *
+ * sprite 的格子就是節點的顯示尺寸 1×（例如骰子 50×53），個別的高解析 WebP 是 2×。
+ * 所以「值不值得換」要問的是：一個使用者座標單位，現在攤到幾個**實體**裝置像素上？
+ * 超過 1 才代表 sprite 的來源解析度已經不夠、需要 2× 素材。
+ *
+ * 兩個門檻不同（遲滯）是為了避免在門檻附近反覆縮放時，圖示在 sprite 與高解析之間來回抖動。
+ */
+export const HIRES_UPGRADE_AT = 1.2;
+export const HIRES_DOWNGRADE_AT = 0.9;
+
+/**
+ * 算出「一個使用者座標單位目前攤到幾個裝置像素」。
+ *
+ * ⚠️ 這是 2026-08-19 review 報告 C05 的核心：舊版的判斷是 `if (vp.scale <= 1) return;`，
+ * 只看 `#viewport` 的**內部倍率**，完全沒有考慮
+ * ①畫布元素相對 viewBox 的基礎縮放、②裝置像素比。結果兩個方向都錯：
+ *
+ * - 1280×720 dpr1：實際每單位只有 0.52 裝置像素（骰子 26 CSS px），卻因為 vp.scale ≈ 1.49
+ *   而升級了 213 張圖（約 500KB）——完全白抓，sprite 綽綽有餘。
+ * - 2560×1440 dpr2：實際 1.41 裝置像素／單位，真的需要 2× 素材，卻因為 vp.scale 沒超過 1
+ *   而一張都不升。
+ *
+ * 公式跟畫布實際怎麼畫是同一套：SVG 用 `preserveAspectRatio` 的 meet 行為，
+ * 基礎縮放＝`min(元素寬/viewBox寬, 元素高/viewBox高)`，再乘上 `#viewport` 的 transform 倍率，
+ * 最後乘裝置像素比換算成實體像素。
+ */
+export function effectiveDevicePx(
+  svgWidth: number,
+  svgHeight: number,
+  viewBoxWidth: number,
+  viewBoxHeight: number,
+  scale: number,
+  devicePixelRatio: number,
+): number {
+  if (viewBoxWidth <= 0 || viewBoxHeight <= 0) return 0;
+  const base = Math.min(svgWidth / viewBoxWidth, svgHeight / viewBoxHeight);
+  return base * scale * devicePixelRatio;
+}
+
 export function minReadableScale(
   containerWidthPx: number,
   containerHeightPx: number,

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -8,11 +8,14 @@ import {
   MOBILE_ICON_TARGET_PX,
   Viewport,
   minReadableScale,
+  effectiveDevicePx,
+  HIRES_UPGRADE_AT,
+  HIRES_DOWNGRADE_AT,
 } from '../lib/viewport.js';
 import { computeSelection } from '../lib/selection.js';
 import { renderDetail } from '../components/NodeDetail.js';
 import { matchesFilter, stateToQueryString, queryStringToState, isTypingTarget } from '../lib/filter.js';
-import { visibleNodeIds, upgradeIcons } from '../lib/hires.js';
+import { visibleNodeIds, upgradeIcons, downgradeIcons, buildIconIndex } from '../lib/hires.js';
 import { FEATURES } from '../lib/flags.js';
 import type { Branch, NodeType, TreeData, TreeNode } from '../lib/types.js';
 
@@ -265,18 +268,55 @@ svg.addEventListener('pointermove', e => {
 // 例外，但「縮放後圖示真的換成高解析版本」這個實際效果本環境驗不到，留給第 18 個任務的
 // E2E 或真機——src/lib/hires.ts 的 upgradeIcons() 本身（拿到正確的可視節點清單之後，
 // DOM 要怎麼改）已經在 tests/lib/hires.test.ts 用真實 SVG DOM 驗過。
+// 節點是建置期一次畫好、之後不再增刪的，圖示元素索引建一次就永遠有效——不必每次縮放都
+// 對每個可見節點各跑一次 querySelector。
+const iconIndex = buildIconIndex(svg);
+
+/**
+ * 目前一個使用者座標單位攤到幾個**裝置**像素。用它決定要不要換 2× 素材，見
+ * `effectiveDevicePx()` 的說明（舊版只看 `vp.scale`，兩個方向都判斷錯）。
+ */
+function currentDevicePx(): number {
+  const box = svg.getBoundingClientRect();
+  const dpr = typeof devicePixelRatio === 'number' && devicePixelRatio > 0 ? devicePixelRatio : 1;
+  return effectiveDevicePx(box.width, box.height, data.meta.viewBox[2], data.meta.viewBox[3], vp.scale, dpr);
+}
+
+/** 每批處理幾個節點。24 是一個手機首屏大致的可見節點量級，夠小到不會卡住一幀。 */
+const UPGRADE_BATCH = 24;
+
+/** 排一段閒置工作（Safari 沒有 requestIdleCallback，照本檔慣例做存在性檢查後退回 setTimeout）。 */
+function whenIdle(fn: () => void): void {
+  if (typeof requestIdleCallback === 'function') requestIdleCallback(() => fn(), { timeout: 1000 });
+  else if (typeof setTimeout === 'function') setTimeout(fn, 0);
+}
+
+function upgradeInBatches(ids: string[], start = 0): void {
+  upgradeIcons(ids.slice(start, start + UPGRADE_BATCH), svg, undefined, iconIndex);
+  if (start + UPGRADE_BATCH < ids.length) whenIdle(() => upgradeInBatches(ids, start + UPGRADE_BATCH));
+}
+
 function maybeUpgradeIcons(): void {
   if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(upgradeRaf);
   if (typeof requestAnimationFrame !== 'function') return;
   upgradeRaf = requestAnimationFrame(() => {
-    if (vp.scale <= 1) return;
+    const devicePx = currentDevicePx();
+    // 遲滯：縮小到明顯不需要 2× 素材時把已升級的換回 sprite（pattern 只增不減會一路吃記憶體，
+    // 實測整棵樹全升級後多出約 4.6MB），但門檻比升級低一截，免得在邊界反覆縮放時來回抖動。
+    if (devicePx < HIRES_DOWNGRADE_AT) {
+      downgradeIcons(iconIndex.values());
+      return;
+    }
+    if (devicePx <= HIRES_UPGRADE_AT) return;
     const g = svg.querySelector<SVGGElement>('#viewport');
     const ctm = g?.getScreenCTM?.()?.inverse();
     if (!ctm) return; // 沒有版面引擎（測試環境）或畫布尚未真正掛進有版面的 DOM，無法換算
     const box = svg.getBoundingClientRect();
     const tl = new DOMPoint(box.left, box.top).matrixTransform(ctm);
     const br = new DOMPoint(box.right, box.bottom).matrixTransform(ctm);
-    upgradeIcons(visibleNodeIds(data, { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y }), svg);
+    // 分批：一次可見節點可能有近百個，全部一口氣建 pattern＋發請求會在同一幀裡卡住主執行緒。
+    // 每個閒置時段做一批，其餘排到下一次——畫面上是圖示陸續變清晰，不是整個卡一下。
+    upgradeInBatches(visibleNodeIds(data, { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y }));
   });
 }
 svg.addEventListener('wheel', maybeUpgradeIcons);
@@ -294,7 +334,13 @@ svg.addEventListener('pointerup', maybeUpgradeIcons);
 // 就 <1 的極端狀況）本來就會被 maybeUpgradeIcons() 內部擋掉，不用在外面再判斷一次
 // isMobile，改成無條件呼叫更準確反映「哪個裝置的初始縮放實際上超過門檻」這件事跟裝置種類
 // 沒有必然關係，是純粹看縮放數字。
-maybeUpgradeIcons();
+// 首屏這一次改成閒置時才做：它有可能一口氣建立上百個 pattern、發出上百個圖片請求，擠在
+// 首次繪製的同一批工作裡只會拖慢「使用者看到第一畫面」的時間，而高解析與否是漸進增強。
+// Safari 沒有 requestIdleCallback（照本檔慣例做存在性檢查後退回 setTimeout）。
+//
+// ⚠️ 門檻修正之後，1280×720 dpr1 的桌機首屏**不會**再升級（實測每單位只有 0.52 裝置像素，
+// sprite 綽綽有餘）——這正是修正的重點，不是退步。高 DPI 螢幕與手機才會在這裡真的升級。
+whenIdle(maybeUpgradeIcons);
 
 // --- 鍵盤：方向鍵平移、+/- 縮放 ---
 // 這個 handler 掛在 window 上、原本不判斷 focus（「不管焦點在哪都該生效」）；但下面

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -174,15 +174,60 @@ test('手機版預設聚焦單一分支且有分支 chip', async ({ page, isMobi
   expect(await getViewportScale(page)).toBeGreaterThan(1.5);
 });
 
-test('首屏資產體積在預算內', async ({ page }) => {
-  let bytes = 0;
-  page.on('response', async r => {
-    if (r.url().includes('/assets/') || r.url().endsWith('.js') || r.url().endsWith('.css')) {
-      bytes += Number((await r.allHeaders())['content-length'] ?? 0);
-    }
+/** 目前一個使用者座標單位攤到幾個裝置像素——高解析升級的真正判準，見 src/lib/viewport.ts。 */
+async function devicePxPerUnit(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const svg = document.querySelector('#tree') as SVGSVGElement;
+    const vp = document.querySelector('#viewport');
+    const box = svg.getBoundingClientRect();
+    const vb = svg.getAttribute('viewBox')!.split(/\s+/).map(Number);
+    const scale = Number(/scale\(([-\d.]+)\)/.exec(vp?.getAttribute('transform') ?? '')?.[1] ?? 1);
+    return Math.min(box.width / vb[2]!, box.height / vb[3]!) * scale * window.devicePixelRatio;
   });
+}
+
+/** 縮到門檻以下，讓已升級的圖示換回 sprite（遲滯門檻 0.9，見 viewport.ts）。 */
+async function zoomOutToSprite(page: Page): Promise<void> {
+  const box = (await page.locator('#tree').boundingBox())!;
+  const point = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  await page.mouse.move(point.x, point.y);
+  for (let i = 0; i < 40; i++) await page.mouse.wheel(0, 120);
+  await page.waitForTimeout(200);
+}
+
+test('首屏資產體積在預算內', async ({ page }) => {
+  // ⚠️ 舊版是假綠的（review 報告 C06）：`page.on('response', async r => …)` 的回呼是
+  // async，Playwright 不會 await 它，`await r.allHeaders()` 還沒回來 goto 就結束了——
+  // 同一頁重跑量到 196KB～646KB 不等。而且靠 content-length，壓縮回應根本沒有這個標頭。
+  //
+  // 改成在頁面端讀 Resource Timing：transferSize 是實際過網路的位元組（含標頭、已壓縮），
+  // 快取命中時是 0，所以退回 encodedBodySize 當下限。這是瀏覽器自己記的帳，不會漏。
   await page.goto('/tree', { waitUntil: 'networkidle' });
-  expect(bytes).toBeLessThan(500 * 1024);
+  // ⚠️ 首屏的高解析升級排在 requestIdleCallback（timeout 1000ms）裡，networkidle 會在它
+  // 開火之前就滿足。不等這一段的話，這個測試量到的永遠是「還沒開始抓圖示」的快照——
+  // 把門檻改回舊版的 `vp.scale <= 1`（桌機會白抓 213 張）它一樣是綠的，等於什麼都沒守。
+  await page.waitForTimeout(1500);
+  await page.waitForLoadState('networkidle');
+  const m = await page.evaluate(() => {
+    const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+    const counted = entries.filter(e =>
+      e.name.includes('/assets/') || e.name.endsWith('.js') || e.name.endsWith('.css'));
+    return {
+      bytes: counted.reduce((a, e) => a + (e.transferSize || e.encodedBodySize || 0), 0),
+      iconRequests: entries.filter(e => e.name.includes('/assets/icons/')).length,
+      names: counted.map(e => e.name.split('/').pop()).slice(0, 5),
+    };
+  });
+  expect(m.bytes, `首屏資產 ${(m.bytes / 1024).toFixed(1)}KB（前幾項：${m.names.join(', ')}）`)
+    .toBeLessThan(500 * 1024);
+
+  // 請求數：這條守的是「不需要 2× 素材時，一張都不該抓」——修正前桌機（每單位 0.52 裝置
+  // 像素）無條件抓 213 張高解析圖示約 500KB，純屬浪費。真的需要 2× 的高 DPI 裝置會抓
+  // （Pixel 7 實測 68 張，體積仍在預算內），那是該做的事，不設上限。
+  const devicePx = await devicePxPerUnit(page);
+  if (devicePx <= 1.2) {
+    expect(m.iconRequests, `每單位 ${devicePx.toFixed(2)} 裝置像素，sprite 已足夠，不該抓個別圖示`).toBe(0);
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -238,12 +283,22 @@ test('C. 縮放 > 1x 後，可見節點圖示從 sprite pattern 換成高解析 
   // 升級過），不是的話代表這個測試的前提不成立，用 test.skip 誠實記錄，不是硬凹。
   await goToNatureBranch(page, isMobile);
   const icon = page.locator('g.node[data-id="1002"] > rect.icon');
-  const startFill = await icon.getAttribute('fill');
-  test.skip(!startFill?.includes('icon-pattern-'), '這個裝置/縮放組合下，分支導覽跳轉後已經是高解析圖示，沒有可觀察的轉換窗口');
+  // 先確保起始狀態真的是 sprite。門檻改成裝置像素後，手機／高 DPI 裝置一載入就已經升級，
+  // 那時沒有可觀察的轉換窗口——先縮到門檻以下把它換回 sprite，測試才有前提可驗。
+  if (!(await icon.getAttribute('fill'))?.includes('icon-pattern-')) {
+    await zoomOutToSprite(page);
+  }
+  await expect
+    .poll(async () => (await icon.getAttribute('fill')) ?? '', { timeout: 5000 })
+    .toContain('icon-pattern-');
 
+  // 放大到跨過裝置像素門檻。用 poll 而不是固定圈數：不同 project 的初始倍率與 DPR 不同，
+  // 「幾圈才夠」不是一個跨裝置成立的常數。
   const point = await centerOf(page.locator('g.node[data-id="1002"]'));
-  await zoomInAt(page, point, 8);
-  expect(await getViewportScale(page)).toBeGreaterThan(1);
+  await expect.poll(async () => {
+    await zoomInAt(page, point, 4);
+    return devicePxPerUnit(page);
+  }, { timeout: 15000 }).toBeGreaterThan(1.2);
 
   // upgradeIcons 是用 wheel 事件節流的 requestAnimationFrame 觸發的（見 tree-canvas.ts），
   // 給瀏覽器一次繪圖機會讓它真的跑完。
@@ -457,13 +512,13 @@ test('H. 鍵盤 focus 的金邊貼合圖示輪廓：圓形節點得到圓環，�
   for (const [x, y] of corners) expect(isGold(at(x, y))).toBe(false);
 });
 
-test('I. 初次載入未經任何互動，只要初始縮放超過 1x，可見節點就已經是高解析圖示', async ({ page }) => {
+test('I. 初次載入未經任何互動，只要真的需要 2× 素材，可見節點就已經是高解析圖示', async ({ page }) => {
   await page.goto('/tree'); // 網址沒帶 ?node=，桌機整棵樹置中、手機預設對準 nature 分支
-  const scale = await getViewportScale(page);
-  // bug 4 修正後，兩種裝置的初始視角都可能超過 1x（手機幾乎必然；桌機則看可讀性下限
-  // 是否高於 fitTo 整棵樹的 0.9x，容器夠扁時會超過，見上面的修正記錄）——只有真的超過
-  // 1x 時，bug 2 的修正才有東西可驗，沒超過就 skip，不是硬凹一個不成立的前提。
-  test.skip(scale <= 1, `初始縮放 ${scale} ≤ 1x，這個裝置/環境下沒有可觀察的「初次載入已經是高解析」窗口`);
+  const devicePx = await devicePxPerUnit(page);
+  // 門檻從「vp.scale > 1」改成「每單位裝置像素 > 1.2」（見 src/lib/viewport.ts 的
+  // effectiveDevicePx）。1280×720 dpr1 的桌機算出來只有約 0.52——**不升級才是對的**，
+  // sprite 的來源解析度綽綽有餘，舊版在這裡白抓 213 張圖約 500KB。
+  test.skip(devicePx <= 1.2, `每單位 ${devicePx.toFixed(2)} 裝置像素 ≤ 1.2，這個裝置不需要 2× 素材（sprite 已足夠）`);
 
   // 完全不做任何滑鼠/觸控互動（不 wheel、不拖曳）。如果 bug 2 還在，這裡會停在 sprite
   // pattern，要等使用者互動一次才會升級。waitForFunction 給 rAF 一次跑的機會（跟測試 C

--- a/tests/lib/viewport.test.ts
+++ b/tests/lib/viewport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseHTML } from 'linkedom';
-import { Viewport, minReadableScale } from '../../src/lib/viewport';
+import { Viewport, minReadableScale, effectiveDevicePx, HIRES_UPGRADE_AT, HIRES_DOWNGRADE_AT } from '../../src/lib/viewport';
 
 function make() {
   const { document } = parseHTML('<html><body></body></html>');
@@ -219,5 +219,41 @@ describe('minReadableScale（task-17/18 裁決：最小可讀縮放下限，純�
     const mobile = minReadableScale(390, 800, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, DICE_ICON_WIDTH_UNITS, 32);
     const desktop = minReadableScale(1200, 800, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, DICE_ICON_WIDTH_UNITS, 32);
     expect(mobile).toBeGreaterThan(desktop);
+  });
+});
+
+describe('effectiveDevicePx（高解析升級的真正判準）', () => {
+  // viewBox 固定 2000×1700（見 CLAUDE.md 的不變量）。
+  const VB: [number, number] = [2000, 1700];
+  const px = (w: number, h: number, scale: number, dpr: number) =>
+    effectiveDevicePx(w, h, VB[0], VB[1], scale, dpr);
+
+  it('1280×720 桌機 dpr1：初始視角不該升級——舊版在這裡白抓了 213 張圖', () => {
+    // 畫布高 595（1280×720 扣掉 nav 與 footer），可讀性下限把 scale 拉到約 1.49。
+    const v = px(1280, 595, 1.49, 1);
+    expect(v).toBeCloseTo(0.52, 1);
+    expect(v).toBeLessThan(HIRES_UPGRADE_AT);
+  });
+
+  it('2560×1440 dpr2：該升級——舊版在這裡一張都沒升', () => {
+    const v = px(2560, 1315, 1.49, 2);
+    expect(v).toBeGreaterThan(HIRES_UPGRADE_AT);
+  });
+
+  it('Pixel 7 手機（412×678 dpr2.625，分支視角 scale≈5.5）：該升級', () => {
+    expect(px(412, 678, 5.5, 2.625)).toBeGreaterThan(HIRES_UPGRADE_AT);
+  });
+
+  it('桌機放大之後就會跨過門檻', () => {
+    expect(px(1280, 595, 1.49, 1)).toBeLessThan(HIRES_UPGRADE_AT);
+    expect(px(1280, 595, 4, 1)).toBeGreaterThan(HIRES_UPGRADE_AT);
+  });
+
+  it('遲滯：升級門檻高於降級門檻，避免在邊界反覆抖動', () => {
+    expect(HIRES_UPGRADE_AT).toBeGreaterThan(HIRES_DOWNGRADE_AT);
+  });
+
+  it('viewBox 壞掉時回 0，不會變成 NaN 一路傳下去', () => {
+    expect(effectiveDevicePx(1280, 595, 0, 1700, 2, 1)).toBe(0);
   });
 });


### PR DESCRIPTION
review 報告的 **P6（hires 圖示載入策略＋E2E 體積預算）**。base 是 PR #8。

## 核心：升級門檻用錯了物理量

舊判斷是 `if (vp.scale <= 1) return;`——只看 `#viewport` 的**內部倍率**，沒有考慮畫布元素相對 viewBox 的基礎縮放，也沒有考慮裝置像素比。兩個方向都錯：

| 情境 | 每單位實際裝置像素 | 舊行為 | 新行為 |
|---|---|---|---|
| 1280×720 dpr1 桌機首屏 | **0.52**（scale 1.4845，實測） | 升級 213 張、**732KB** | 不升級 ✅ |
| 2560×1440 dpr2 | 1.41 | 不升級 | 升級 ✅ |
| Pixel 7（dpr 2.625，分支視角） | 遠超門檻 | 升級 | 升級 ✅ |

sprite 的格子就是節點顯示尺寸的 1×，個別 WebP 是 2×。該問的是「一個使用者座標單位攤到幾個**實體**像素」，不是「viewport 的倍率是多少」。

抽成純函式 `effectiveDevicePx(svgW, svgH, vbW, vbH, scale, dpr)` 放在 `src/lib/viewport.ts`，公式跟瀏覽器畫 SVG 的 `preserveAspectRatio` meet 行為一致。門檻加遲滯：`> 1.2` 升級、`< 0.9` 降回 sprite，避免在邊界反覆縮放時抖動。

## 其他

- **首屏改排在 `requestIdleCallback`**（Safari 沒有 → 退回 `setTimeout`），並**分批**（每批 24 個）——一口氣建上百個 pattern＋發上百個請求會卡住同一幀
- **圖示元素索引建一次**（`buildIconIndex`）：節點是建置期畫好、之後不增刪的，不必每次縮放都對每個可見節點各跑一次 `querySelector`
- **`downgradeIcons()`**：縮小到門檻以下把已升級的換回 sprite（pattern 只增不減，實測整棵樹全升級多出約 4.6MB）
- **載入失敗自動止血**：高解析 WebP 的 `<image>` 加 `error` 監聽 → 把用到該 pattern 的節點全換回 sprite 並移除 pattern。以前是一塊什麼都沒有的空白節點，且沒有任何錯誤訊息

## E2E 體積預算：原本是假綠的

`page.on('response', async r => { … await r.allHeaders() … })` 的回呼是 async，Playwright 不會 await 它——`goto` 結束時多數標頭還沒回來，同一頁重跑量到 196KB～646KB 不等。而且靠 `content-length`，壓縮回應根本沒這個標頭。

改成在頁面端讀 Resource Timing 的 `transferSize`（快取命中為 0 時退回 `encodedBodySize`），並加一條「不需要 2× 素材時，個別圖示請求數必須是 0」。

⚠️ **這個測試我第一版寫錯過一次**：首屏升級排在 `requestIdleCallback(timeout 1000)` 裡，`networkidle` 會在它開火前就滿足，所以量到的是「還沒開始抓圖示」的快照——把門檻改回舊版它一樣是綠的。加了 `waitForTimeout(1500)` ＋ 再等一次 `networkidle` 才真的守得住。

## 驗證

```
npm run validate  ✅ ／ npm run typecheck ✅
npm test          ✅ 279 tests（先前 273，新增 6）
npm run e2e       ✅ 55 passed / 7 skipped
```

弄壞會不會紅（**這次記得先 `npm run build`**——`npx playwright test` 不會重建，不建的話測到的是舊產物，我第一輪就是這樣得到一個假的「沒紅」）：

```
門檻改回 `vp.scale <= 1` → 首屏資產體積在預算內 ✘
    Expected: < 512000
    Received:   732479
effectiveDevicePx 忽略 dpr → 2 條單元測試紅（2560×1440 dpr2、Pixel 7）
```

測試 C 改成先縮回 sprite 再放大到跨過裝置像素門檻（用 `expect.poll` 而不是寫死圈數——不同 project 的初始倍率與 DPR 不同，「幾圈才夠」不是跨裝置成立的常數）。測試 I 的 skip 條件從 `scale <= 1` 改成 `devicePx <= 1.2`，並改名為「只要真的需要 2× 素材」。

## 沒做的

- 「高解析圖載入完成前保留 sprite fill」只做了失敗路徑（`error` → 換回 sprite）。載入中那一瞬間 `<pattern>` 裡的 `<image>` 還沒畫出來，節點會閃一下空白——要根治得先用 `Image` 預載再換 fill，那會讓現有同步行為的單元測試與 E2E 全部要改，價值不成比例。
- pattern 的 LRU 回收：改用遲滯降級之後，縮小就會整批換回 sprite，實務上不會再無限累積。
