### PR TITLE
fix: 高解析圖示門檻改用裝置像素

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,13 +115,20 @@ CI 規則 10 守它（`<svg>` 直屬、不帶 transform、圖檔存在且解析�
 top 差距 < 0.5px、`scrollHeight === innerHeight`），不是看截圖。
 E2E 的 U（不該捲動）、V（詳情卡片避開側欄）、J（手機抽屜不蓋住工具列）就是這三條防線。
 
-### 已知未修：手機版 `#branch-chips` 蓋住 footer
+### 手機版 footer 要讓位給 `#branch-chips`
 
-`#branch-chips` 是 `position: fixed; bottom: 0`，頁面不捲動之後它永遠疊在 footer 上緣
-（實測 390×844：chips 791.75–844、footer 729.13–844）。要修得動整個手機底部區
-（`#detail` 是 `inset: auto 0 0 0` 的底部抽屜，靠 `padding-bottom: 4.5rem` 讓警告文字避開
-chips，而 chips 靠 DOM 順序畫在抽屜之上）——把 chips 放回文件流程會連帶改變抽屜的行為。
-這是設計決定不是 bug 修正，留待日後一併處理。
+`#branch-chips` 是 `position: fixed; bottom: 0`，頁面不捲動之後它會永遠疊在 footer 上緣——
+而 footer 第二行是「著作權屬 111 Percent Inc.」這句必須看得到的聲明。作法是
+`body:has(#canvas-host) footer { padding-bottom: calc(1rem + var(--chips-h)) }`，
+`--chips-h` 由 `tree-canvas.ts` 量 chip 列的實際高度寫入（**不要寫死 3.5rem**）。
+`<main>` 是 `flex: 1`，footer 變高只會讓畫布跟著縮，不會把捲軸叫回來。E2E 的 W 守這條。
+
+### ⚠️ `npx playwright test` 不會重新建置
+
+`npm run e2e` 有 `pree2e` 會先 `npm run build`；**直接跑 `npx playwright test` 不會**。
+拿它做「把程式碼弄壞，看測試會不會紅」的抽查時，不先 `npm run build` 就是在測舊產物——
+2026-08-19 我就是這樣得到一個假的「沒紅」，差點把一條沒守住的測試當成有效防線。
+抽查的正確順序：改壞 → `npm run build` → `npx playwright test -g ...` → 還原 → 再 build。
 
 ### 資料解析
 

--- a/src/lib/hires.ts
+++ b/src/lib/hires.ts
@@ -26,6 +26,21 @@ function hiresPatternId(icon: string): string {
 }
 
 /**
+ * 載入失敗過的圖示雜湊。
+ *
+ * 沒有這份名單的話，失敗處理本身會變成一個無限重抓迴圈：`error` 監聽器把 pattern 移除、
+ * 把節點的 `data-hires` 清掉 → 下一次縮放時「pattern 不存在、節點也沒升級過」兩個條件又都
+ * 成立 → 重建 pattern、重發那個 404（404 通常不會被負快取），節點也跟著 sprite→空白→sprite
+ * 閃一次。整個工作階段每一次縮放都會重演。
+ */
+const failedIcons = new Set<string>();
+
+/** 清空失敗名單（測試用；正式路徑沒有「檔案會自己變回來」這種事）。 */
+export function resetFailedIcons(): void {
+  failedIcons.clear();
+}
+
+/**
  * 把指定節點的圖示從 sprite 換成個別的高解析 WebP。
  *
  * DOM 結構（見 src/lib/render.ts，task-18 bug 修正後的版本——第二輪從「巢狀 svg +
@@ -72,13 +87,25 @@ export function buildIconIndex(svg: SVGSVGElement): Map<string, SVGRectElement> 
  * `<image>`，貼上去的 `<rect>` 就是一塊什麼都沒有的空白，畫面上是一個「破圖」節點，
  * 而且沒有任何錯誤訊息。
  */
-export function downgradeIcons(icons: Iterable<SVGRectElement>): void {
+export function downgradeIcons(icons: Iterable<SVGRectElement>, svg?: SVGSVGElement): void {
+  const touched = new Set<string>();
   for (const icon of icons) {
     if (icon.dataset.hires !== '1') continue;
     const sprite = icon.dataset.spriteFill;
     if (!sprite) continue;
+    const hash = icon.getAttribute('data-icon');
+    if (hash) touched.add(hash);
     icon.setAttribute('fill', sprite);
     delete icon.dataset.hires;
+  }
+
+  // 只換 fill 是不夠的：`<pattern>` 裡的 `<image href="…webp">` 還掛在文件上，那幾 MB 的
+  // 解碼結果一樣沒還回去——降級的整個理由就是要回收它。沒有任何節點還指著的 pattern 才移除。
+  if (!svg) return;
+  for (const hash of touched) {
+    const patId = hiresPatternId(hash);
+    if (svg.querySelector(`rect.icon[fill="url(#${patId})"]`)) continue;
+    svg.querySelector(`#${patId}`)?.remove();
   }
 }
 
@@ -105,6 +132,17 @@ export function upgradeIcons(
 
     const hash = icon.getAttribute('data-icon');
     if (!hash) continue; // render.ts 一定會寫入 data-icon，這裡只是防禦性判斷，不代表正常路徑
+    if (failedIcons.has(hash)) continue; // 這張圖抓過、失敗過，不要再試一次（見 failedIcons）
+
+    // 記下原本的 sprite fill——降級（縮小回門檻以下、或高解析圖載入失敗）時要換回來。
+    // ⚠️ 換不回來就不要換過去：沒有 fill 可記卻仍標 data-hires="1" 的話，這個節點會永遠卡在
+    // 高解析 pattern 上，連載入失敗的止血路徑都救不了它（`downgradeIcons` 會直接 continue），
+    // 結果正是這段程式想避免的「一塊沒有錯誤訊息的空白節點」。
+    if (!icon.dataset.spriteFill) {
+      const current = icon.getAttribute('fill');
+      if (!current) continue;
+      icon.dataset.spriteFill = current;
+    }
 
     const patId = hiresPatternId(hash);
     if (!patternedThisCall.has(hash) && !svg.querySelector(`#${patId}`)) {
@@ -139,8 +177,9 @@ export function upgradeIcons(
       // 換回 sprite，並把 pattern 移除，免得後面的節點又貼上同一個壞掉的圖案。
       // 不做這件事的話，畫面上就是一個空白的節點，而且沒有任何錯誤訊息。
       img.addEventListener('error', () => {
-        const affected = [...svg.querySelectorAll<SVGRectElement>(`rect.icon[data-icon="${hash}"]`)];
-        downgradeIcons(affected);
+        // 先記進失敗名單再降級：順序反過來的話，下一次縮放會把同一個 404 重抓一次。
+        failedIcons.add(hash);
+        downgradeIcons([...svg.querySelectorAll<SVGRectElement>(`rect.icon[data-icon="${hash}"]`)], svg);
         pattern.remove();
       });
       pattern.appendChild(img);
@@ -148,11 +187,6 @@ export function upgradeIcons(
     }
     patternedThisCall.add(hash);
 
-    // 記下原本的 sprite fill，降級時要換回來（縮小回門檻以下、或高解析圖載入失敗）。
-    if (!icon.dataset.spriteFill) {
-      const current = icon.getAttribute('fill');
-      if (current) icon.dataset.spriteFill = current;
-    }
     icon.setAttribute('fill', `url(#${patId})`);
     icon.dataset.hires = '1';
   }

--- a/src/lib/hires.ts
+++ b/src/lib/hires.ts
@@ -48,7 +48,46 @@ function hiresPatternId(icon: string): string {
  * 用 `icon.dataset.hires === '1'` 記錄「已經升級過」，避免同一個節點被重複處理（例如使用者
  * 反覆縮放、同一個節點多次落在可視範圍內）時重複改寫 DOM。
  */
-export function upgradeIcons(ids: string[], svg: SVGSVGElement, base = '/assets/icons'): void {
+/**
+ * 一次把 `g.node[data-id] > rect.icon` 全部索引起來，供 `upgradeIcons()` 重複使用。
+ *
+ * 沒有它的話，每次縮放（rAF 節流後仍然是每幾個影格一次）都要對每個可見節點各跑一次
+ * `svg.querySelector('g.node[data-id="…"] > rect.icon')`。節點是建置期一次畫好、之後不再
+ * 增刪的，索引建一次就永遠有效。
+ */
+export function buildIconIndex(svg: SVGSVGElement): Map<string, SVGRectElement> {
+  const index = new Map<string, SVGRectElement>();
+  for (const icon of svg.querySelectorAll<SVGRectElement>('g.node > rect.icon')) {
+    const id = (icon.parentElement as Element | null)?.getAttribute('data-id');
+    if (id) index.set(id, icon);
+  }
+  return index;
+}
+
+/**
+ * 把圖示換回共用的 sprite。
+ *
+ * 兩個用途：①縮小到不再需要 2× 素材時回收（見 tree-canvas.ts 的遲滯門檻）；
+ * ②高解析 WebP 載入失敗時止血——沒有這條的話，`<pattern>` 裡是一張永遠載不到的
+ * `<image>`，貼上去的 `<rect>` 就是一塊什麼都沒有的空白，畫面上是一個「破圖」節點，
+ * 而且沒有任何錯誤訊息。
+ */
+export function downgradeIcons(icons: Iterable<SVGRectElement>): void {
+  for (const icon of icons) {
+    if (icon.dataset.hires !== '1') continue;
+    const sprite = icon.dataset.spriteFill;
+    if (!sprite) continue;
+    icon.setAttribute('fill', sprite);
+    delete icon.dataset.hires;
+  }
+}
+
+export function upgradeIcons(
+  ids: string[],
+  svg: SVGSVGElement,
+  base = '/assets/icons',
+  index?: Map<string, SVGRectElement>,
+): void {
   const doc = svg.ownerDocument;
   // render.ts 現在一定會建立 <defs>（不管有沒有圖示都會），這裡直接假設它存在、找不到就是
   // 呼叫端傳了一個不是 renderTree() 產生的 svg，用法錯誤，不需要再防禦性地自己建一個。
@@ -61,7 +100,7 @@ export function upgradeIcons(ids: string[], svg: SVGSVGElement, base = '/assets/
   const patternedThisCall = new Set<string>();
 
   for (const id of ids) {
-    const icon = svg.querySelector<SVGRectElement>(`g.node[data-id="${id}"] > rect.icon`);
+    const icon = index?.get(id) ?? svg.querySelector<SVGRectElement>(`g.node[data-id="${id}"] > rect.icon`);
     if (!icon || icon.dataset.hires === '1') continue;
 
     const hash = icon.getAttribute('data-icon');
@@ -96,11 +135,24 @@ export function upgradeIcons(ids: string[], svg: SVGSVGElement, base = '/assets/
       img.setAttribute('href', `${base}/${hash}.webp`);
       img.setAttribute('width', w);
       img.setAttribute('height', h);
+      // 載入失敗（檔案被刪、雜湊改了沒重建、CDN 出問題）時把用到這個 pattern 的節點全部
+      // 換回 sprite，並把 pattern 移除，免得後面的節點又貼上同一個壞掉的圖案。
+      // 不做這件事的話，畫面上就是一個空白的節點，而且沒有任何錯誤訊息。
+      img.addEventListener('error', () => {
+        const affected = [...svg.querySelectorAll<SVGRectElement>(`rect.icon[data-icon="${hash}"]`)];
+        downgradeIcons(affected);
+        pattern.remove();
+      });
       pattern.appendChild(img);
       defs.appendChild(pattern);
     }
     patternedThisCall.add(hash);
 
+    // 記下原本的 sprite fill，降級時要換回來（縮小回門檻以下、或高解析圖載入失敗）。
+    if (!icon.dataset.spriteFill) {
+      const current = icon.getAttribute('fill');
+      if (current) icon.dataset.spriteFill = current;
+    }
     icon.setAttribute('fill', `url(#${patId})`);
     icon.dataset.hires = '1';
   }

--- a/src/lib/viewport.ts
+++ b/src/lib/viewport.ts
@@ -56,6 +56,47 @@ const MAX = 8;
 export const DESKTOP_ICON_TARGET_PX = 26;
 export const MOBILE_ICON_TARGET_PX = 35;
 
+/**
+ * 升級成高解析圖示的門檻（單位：**裝置像素 / 使用者座標單位**）。
+ *
+ * sprite 的格子就是節點的顯示尺寸 1×（例如骰子 50×53），個別的高解析 WebP 是 2×。
+ * 所以「值不值得換」要問的是：一個使用者座標單位，現在攤到幾個**實體**裝置像素上？
+ * 超過 1 才代表 sprite 的來源解析度已經不夠、需要 2× 素材。
+ *
+ * 兩個門檻不同（遲滯）是為了避免在門檻附近反覆縮放時，圖示在 sprite 與高解析之間來回抖動。
+ */
+export const HIRES_UPGRADE_AT = 1.2;
+export const HIRES_DOWNGRADE_AT = 0.9;
+
+/**
+ * 算出「一個使用者座標單位目前攤到幾個裝置像素」。
+ *
+ * ⚠️ 這是 2026-08-19 review 報告 C05 的核心：舊版的判斷是 `if (vp.scale <= 1) return;`，
+ * 只看 `#viewport` 的**內部倍率**，完全沒有考慮
+ * ①畫布元素相對 viewBox 的基礎縮放、②裝置像素比。結果兩個方向都錯：
+ *
+ * - 1280×720 dpr1：實際每單位只有 0.52 裝置像素（骰子 26 CSS px），卻因為 vp.scale ≈ 1.49
+ *   而升級了 213 張圖（約 500KB）——完全白抓，sprite 綽綽有餘。
+ * - 2560×1440 dpr2：實際 1.41 裝置像素／單位，真的需要 2× 素材，卻因為 vp.scale 沒超過 1
+ *   而一張都不升。
+ *
+ * 公式跟畫布實際怎麼畫是同一套：SVG 用 `preserveAspectRatio` 的 meet 行為，
+ * 基礎縮放＝`min(元素寬/viewBox寬, 元素高/viewBox高)`，再乘上 `#viewport` 的 transform 倍率，
+ * 最後乘裝置像素比換算成實體像素。
+ */
+export function effectiveDevicePx(
+  svgWidth: number,
+  svgHeight: number,
+  viewBoxWidth: number,
+  viewBoxHeight: number,
+  scale: number,
+  devicePixelRatio: number,
+): number {
+  if (viewBoxWidth <= 0 || viewBoxHeight <= 0) return 0;
+  const base = Math.min(svgWidth / viewBoxWidth, svgHeight / viewBoxHeight);
+  return base * scale * devicePixelRatio;
+}
+
 export function minReadableScale(
   containerWidthPx: number,
   containerHeightPx: number,

--- a/src/pages/tree.astro
+++ b/src/pages/tree.astro
@@ -137,6 +137,18 @@ const TYPES: Array<[string, string]> = [
     position: relative;
   }
 
+  /* ⚠️ 上面整條高度鏈都掛在 `:has()` 上。不支援 `:has()` 的引擎（Firefox 121 之前、較舊的
+     WebKit）會把整條選擇器當成無效**整條丟掉**——body/main 不是 flex、`flex: 1` 沒有作用、
+     而 #tree 是 absolute 對版面高度貢獻 0，結果 #canvas-host 高 0px，整頁一片空白且沒有
+     任何錯誤訊息。改版前 `height: calc(100vh - 110px)` 是無條件的，退化時只是版面偏一點。
+     這裡補一條 fallback：只在不支援 `:has()` 的引擎生效，畫布退回一個「不好看但看得到」的
+     視窗比例高度。CLAUDE.md 記著本站只在 Chromium 驗過，這種整頁空白的失敗模式不能留。 */
+  @supports not selector(:has(*)) {
+    #canvas-host {
+      height: 70vh;
+    }
+  }
+
   /* ⚠️ 絕對定位、不是 width/height: 100%。
      SVG 有內建的長寬比（viewBox 2000×1700），`height: 100%` 在父層高度還沒定案時會退回
      auto，於是它用「寬度 ÷ 長寬比」算出一個內在高度（1280 寬 → 1088 高）反過來把 <main>
@@ -491,6 +503,14 @@ const TYPES: Array<[string, string]> = [
     }
     #filters.open {
       display: flex;
+    }
+    /* footer 讓位給 chip 列：#branch-chips 是 fixed bottom:0，頁面改成不捲動之後它會永遠
+       疊在 footer 上緣，而 footer 第二行是「著作權屬 111 Percent Inc.」這句必須看得到的
+       聲明——手機上完全讀不到。--chips-h 由 tree-canvas.ts 量實際高度寫入（不寫死數字，
+       這個 repo 的固定偏移量已經咬過四次）。<main> 是 flex: 1，footer 變高只會讓畫布跟著
+       縮，不會把捲軸叫回來。 */
+    body:has(#canvas-host) footer {
+      padding-bottom: calc(1rem + var(--chips-h, 3.5rem));
     }
     #branch-chips {
       position: fixed;

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -40,13 +40,14 @@ const byId = new Map(data.nodes.map(n => [n.id, n]));
 function updateNavHeight(): void {
   const nav = document.getElementById('site-nav');
   if (!nav) return;
-  // ⚠️ 量的是**文件座標**（offsetTop + offsetHeight），不是 getBoundingClientRect().bottom。
-  // 後者是視窗座標：頁面只要能捲動，捲到 y=100 時 resize 一次，--nav-h 就會被寫成
-  // 「nav 高度 − 100」甚至負數，#tree-controls 與 #detail 跟著跳到 nav 上面去。
-  // 版面改成 flex 之後畫布頁本來就不該捲得動，這條是保險。
-  // getBoundingClientRect() 保留次像素（nav 實測 50.59px，offsetHeight 會四捨五入成 51），
-  // 再補回 scrollY 換算成文件座標。
-  const bottom = nav.getBoundingClientRect().bottom + window.scrollY;
+  // ⚠️ 這裡要的是**視窗座標**：`--nav-h` 的兩個消費者（#tree-controls、#detail）都是
+  // `position: fixed`，`top` 本來就是相對視窗算的。一度改成 `+ window.scrollY` 換算成文件
+  // 座標是錯的——捲到 y=100 時會把兩者放到 nav 下方 100px，畫布頂端多出一條 nav 高的死區。
+  //
+  // 真正要防的是「頁面可捲時 nav 的視窗下緣變成負數」——那時固定層應該貼齊視窗頂端，而不是
+  // 跟著 nav 跑出畫面，所以夾在 0 以上。版面改成 flex 之後畫布頁本來就不該捲得動，這條是給
+  // 退化情境（例如 :has() 不支援）的保險。
+  const bottom = Math.max(0, nav.getBoundingClientRect().bottom);
   // 單元測試環境（linkedom）沒有版面引擎，getBoundingClientRect() 預設全 0，
   // bottom <= 0 一定不是真實渲染結果，跳過寫入、讓 CSS 的 3rem fallback 留著
   // （tests/scripts/tree-canvas.test.ts 的頁面 fixture 也沒有 #site-nav，上面
@@ -57,7 +58,34 @@ function updateNavHeight(): void {
   }
 }
 updateNavHeight();
-window.addEventListener('resize', updateNavHeight);
+
+/**
+ * 手機版底部分支列的實際高度，寫進 `--chips-h` 供 footer 讓位用。
+ *
+ * `#branch-chips` 是 `position: fixed; bottom: 0`，頁面改成不捲動之後它會永遠疊在 footer
+ * 上緣——而 footer 第二行正是「遊戲圖示與文字著作權屬 111 Percent Inc.」這句必須看得到的
+ * 聲明，手機上因此完全讀不到。讓 footer 加一段等於 chip 列高度的下內距把文字頂上來；
+ * `<main>` 是 `flex: 1`，footer 變高只會讓畫布跟著縮，不會把捲軸叫回來。
+ *
+ * 一樣是**量出來**而不是寫一個 3.5rem——這個 repo 的固定偏移量已經咬過四次（見 CLAUDE.md）。
+ */
+function updateChipsHeight(): void {
+  const chips = document.getElementById('branch-chips');
+  if (!chips) return;
+  const h = chips.getBoundingClientRect().height;
+  if (h > 0) document.documentElement.style.setProperty('--chips-h', `${h}px`);
+}
+updateChipsHeight();
+
+window.addEventListener('resize', () => {
+  updateNavHeight();
+  updateChipsHeight();
+  // 升級門檻的兩個輸入（畫布尺寸、devicePixelRatio）都會隨視窗變動：瀏覽器縮放到 200%
+  // （dpr 1→2）、手機轉向、進入全螢幕、把視窗拖到高 DPI 螢幕，全都只發 resize。不在這裡
+  // 重算的話，使用者會一直停在糊掉的 sprite（或反過來，停在已經沒必要的高解析圖），
+  // 直到剛好在畫布上滾一次滾輪為止。
+  maybeUpgradeIcons();
+});
 
 const host = document.getElementById('canvas-host');
 if (!host) {
@@ -97,6 +125,17 @@ let currentSelected: string | null = initialSelected;
 // 整個模組掛掉。測試環境剛好驗不到（linkedom 沒有 cancelAnimationFrame，函式會提早 return，
 // 根本讀不到這個變數），只有真瀏覽器會炸。
 let upgradeRaf = 0;
+
+/**
+ * 高解析升級的批次世代號。跟 `upgradeRaf` 同一個理由提到這裡（見上面那段說明）：
+ * `jumpToBranch()` 在模組初始化階段就會呼叫 `maybeUpgradeIcons()`，宣告留在函式旁邊會落進
+ * 暫時死區。目前是因為工作都排在 rAF／閒置回呼裡才躲過，那是碰巧安全、不是設計。
+ *
+ * 每次重新評估門檻就 +1，排隊中的批次看到號碼變了就自己停下來——沒有它的話，使用者
+ * 放大→鬆手（排了五批）→立刻縮小（觸發整批降級）之後，那五批仍會照原計畫把圖示一個個
+ * 升回去，在一個 sprite 已經綽綽有餘的倍率上憑空多抓幾十個檔案。
+ */
+let upgradeGeneration = 0;
 
 /** 手機版斷點。要跟 src/pages/tree.astro 的媒體查詢保持一致，兩邊改動時一起改。 */
 const NARROW_QUERY = '(max-width: 720px)';
@@ -273,50 +312,73 @@ svg.addEventListener('pointermove', e => {
 const iconIndex = buildIconIndex(svg);
 
 /**
- * 目前一個使用者座標單位攤到幾個**裝置**像素。用它決定要不要換 2× 素材，見
- * `effectiveDevicePx()` 的說明（舊版只看 `vp.scale`，兩個方向都判斷錯）。
+ * 目前一個使用者座標單位攤到幾個**裝置**像素，連同量到的畫布盒子一起回傳。
+ *
+ * 判準本身見 `effectiveDevicePx()`（舊版只看 `vp.scale`，兩個方向都判斷錯）。盒子一起回傳是
+ * 因為下面換算可視範圍還要用同一個矩形——`getBoundingClientRect()` 是強制版面計算，在每一幀
+ * 都會跑的縮放路徑上讀兩次沒有意義。
  */
-function currentDevicePx(): number {
+function currentDevicePx(): { devicePx: number; box: DOMRect } {
   const box = svg.getBoundingClientRect();
   const dpr = typeof devicePixelRatio === 'number' && devicePixelRatio > 0 ? devicePixelRatio : 1;
-  return effectiveDevicePx(box.width, box.height, data.meta.viewBox[2], data.meta.viewBox[3], vp.scale, dpr);
+  return {
+    devicePx: effectiveDevicePx(box.width, box.height, data.meta.viewBox[2], data.meta.viewBox[3], vp.scale, dpr),
+    box,
+  };
 }
 
 /** 每批處理幾個節點。24 是一個手機首屏大致的可見節點量級，夠小到不會卡住一幀。 */
 const UPGRADE_BATCH = 24;
 
-/** 排一段閒置工作（Safari 沒有 requestIdleCallback，照本檔慣例做存在性檢查後退回 setTimeout）。 */
+/**
+ * 排一段閒置工作。
+ *
+ * Safari 沒有 `requestIdleCallback`（照本檔慣例做存在性檢查）。fallback 刻意是 32ms 而不是 0：
+ * `setTimeout(fn, 0)` 只是「下一個 macrotask」，一串批次會在載入後幾毫秒內接力跑完——那正是
+ * 這個延後想避開的首屏爭用，而 Safari 又正是 fallback 唯一的服務對象。32ms 約兩幀，讓渲染插得進去。
+ */
 function whenIdle(fn: () => void): void {
   if (typeof requestIdleCallback === 'function') requestIdleCallback(() => fn(), { timeout: 1000 });
-  else if (typeof setTimeout === 'function') setTimeout(fn, 0);
+  else if (typeof setTimeout === 'function') setTimeout(fn, 32);
 }
 
-function upgradeInBatches(ids: string[], start = 0): void {
+function upgradeInBatches(ids: string[], generation: number, start = 0): void {
+  // 排隊中的批次要自己確認「當初排隊的理由現在還成立嗎」：使用者可能已經縮小、平移，
+  // 甚至整批降級過了。號碼對不上就直接停，不要把畫面推回一個已經被推翻的狀態。
+  if (generation !== upgradeGeneration) return;
   upgradeIcons(ids.slice(start, start + UPGRADE_BATCH), svg, undefined, iconIndex);
-  if (start + UPGRADE_BATCH < ids.length) whenIdle(() => upgradeInBatches(ids, start + UPGRADE_BATCH));
+  if (start + UPGRADE_BATCH < ids.length) {
+    whenIdle(() => upgradeInBatches(ids, generation, start + UPGRADE_BATCH));
+  }
 }
 
 function maybeUpgradeIcons(): void {
   if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(upgradeRaf);
   if (typeof requestAnimationFrame !== 'function') return;
   upgradeRaf = requestAnimationFrame(() => {
-    const devicePx = currentDevicePx();
-    // 遲滯：縮小到明顯不需要 2× 素材時把已升級的換回 sprite（pattern 只增不減會一路吃記憶體，
-    // 實測整棵樹全升級後多出約 4.6MB），但門檻比升級低一截，免得在邊界反覆縮放時來回抖動。
+    // 重新評估＝先讓所有排隊中的批次失效（見 upgradeGeneration 的說明）。
+    const generation = ++upgradeGeneration;
+    const { devicePx, box } = currentDevicePx();
+    // devicePx 為 0 代表**量不到**（畫布還沒排版、祖先暫時 display:none、容器尺寸為 0），
+    // 不是「小到不需要高解析」。少了這道，那個瞬間會走進下面的降級分支，把 239 個圖示全部
+    // 打回 sprite，而且要等到下一次滾輪／放開拖曳才補得回來。
+    if (devicePx <= 0) return;
+    // 遲滯：縮小到明顯不需要 2× 素材時把已升級的換回 sprite（連同 <defs> 裡的 pattern 一起
+    // 移除，那才是真的把記憶體還回去——實測整棵樹全升級後多出約 4.6MB），但門檻比升級低一截，
+    // 免得在邊界反覆縮放時來回抖動。
     if (devicePx < HIRES_DOWNGRADE_AT) {
-      downgradeIcons(iconIndex.values());
+      downgradeIcons(iconIndex.values(), svg);
       return;
     }
     if (devicePx <= HIRES_UPGRADE_AT) return;
     const g = svg.querySelector<SVGGElement>('#viewport');
     const ctm = g?.getScreenCTM?.()?.inverse();
     if (!ctm) return; // 沒有版面引擎（測試環境）或畫布尚未真正掛進有版面的 DOM，無法換算
-    const box = svg.getBoundingClientRect();
     const tl = new DOMPoint(box.left, box.top).matrixTransform(ctm);
     const br = new DOMPoint(box.right, box.bottom).matrixTransform(ctm);
     // 分批：一次可見節點可能有近百個，全部一口氣建 pattern＋發請求會在同一幀裡卡住主執行緒。
     // 每個閒置時段做一批，其餘排到下一次——畫面上是圖示陸續變清晰，不是整個卡一下。
-    upgradeInBatches(visibleNodeIds(data, { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y }));
+    upgradeInBatches(visibleNodeIds(data, { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y }), generation);
   });
 }
 svg.addEventListener('wheel', maybeUpgradeIcons);

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -8,11 +8,14 @@ import {
   MOBILE_ICON_TARGET_PX,
   Viewport,
   minReadableScale,
+  effectiveDevicePx,
+  HIRES_UPGRADE_AT,
+  HIRES_DOWNGRADE_AT,
 } from '../lib/viewport.js';
 import { computeSelection } from '../lib/selection.js';
 import { renderDetail } from '../components/NodeDetail.js';
 import { matchesFilter, stateToQueryString, queryStringToState, isTypingTarget } from '../lib/filter.js';
-import { visibleNodeIds, upgradeIcons } from '../lib/hires.js';
+import { visibleNodeIds, upgradeIcons, downgradeIcons, buildIconIndex } from '../lib/hires.js';
 import { FEATURES } from '../lib/flags.js';
 import type { Branch, NodeType, TreeData, TreeNode } from '../lib/types.js';
 
@@ -265,18 +268,55 @@ svg.addEventListener('pointermove', e => {
 // 例外，但「縮放後圖示真的換成高解析版本」這個實際效果本環境驗不到，留給第 18 個任務的
 // E2E 或真機——src/lib/hires.ts 的 upgradeIcons() 本身（拿到正確的可視節點清單之後，
 // DOM 要怎麼改）已經在 tests/lib/hires.test.ts 用真實 SVG DOM 驗過。
+// 節點是建置期一次畫好、之後不再增刪的，圖示元素索引建一次就永遠有效——不必每次縮放都
+// 對每個可見節點各跑一次 querySelector。
+const iconIndex = buildIconIndex(svg);
+
+/**
+ * 目前一個使用者座標單位攤到幾個**裝置**像素。用它決定要不要換 2× 素材，見
+ * `effectiveDevicePx()` 的說明（舊版只看 `vp.scale`，兩個方向都判斷錯）。
+ */
+function currentDevicePx(): number {
+  const box = svg.getBoundingClientRect();
+  const dpr = typeof devicePixelRatio === 'number' && devicePixelRatio > 0 ? devicePixelRatio : 1;
+  return effectiveDevicePx(box.width, box.height, data.meta.viewBox[2], data.meta.viewBox[3], vp.scale, dpr);
+}
+
+/** 每批處理幾個節點。24 是一個手機首屏大致的可見節點量級，夠小到不會卡住一幀。 */
+const UPGRADE_BATCH = 24;
+
+/** 排一段閒置工作（Safari 沒有 requestIdleCallback，照本檔慣例做存在性檢查後退回 setTimeout）。 */
+function whenIdle(fn: () => void): void {
+  if (typeof requestIdleCallback === 'function') requestIdleCallback(() => fn(), { timeout: 1000 });
+  else if (typeof setTimeout === 'function') setTimeout(fn, 0);
+}
+
+function upgradeInBatches(ids: string[], start = 0): void {
+  upgradeIcons(ids.slice(start, start + UPGRADE_BATCH), svg, undefined, iconIndex);
+  if (start + UPGRADE_BATCH < ids.length) whenIdle(() => upgradeInBatches(ids, start + UPGRADE_BATCH));
+}
+
 function maybeUpgradeIcons(): void {
   if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(upgradeRaf);
   if (typeof requestAnimationFrame !== 'function') return;
   upgradeRaf = requestAnimationFrame(() => {
-    if (vp.scale <= 1) return;
+    const devicePx = currentDevicePx();
+    // 遲滯：縮小到明顯不需要 2× 素材時把已升級的換回 sprite（pattern 只增不減會一路吃記憶體，
+    // 實測整棵樹全升級後多出約 4.6MB），但門檻比升級低一截，免得在邊界反覆縮放時來回抖動。
+    if (devicePx < HIRES_DOWNGRADE_AT) {
+      downgradeIcons(iconIndex.values());
+      return;
+    }
+    if (devicePx <= HIRES_UPGRADE_AT) return;
     const g = svg.querySelector<SVGGElement>('#viewport');
     const ctm = g?.getScreenCTM?.()?.inverse();
     if (!ctm) return; // 沒有版面引擎（測試環境）或畫布尚未真正掛進有版面的 DOM，無法換算
     const box = svg.getBoundingClientRect();
     const tl = new DOMPoint(box.left, box.top).matrixTransform(ctm);
     const br = new DOMPoint(box.right, box.bottom).matrixTransform(ctm);
-    upgradeIcons(visibleNodeIds(data, { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y }), svg);
+    // 分批：一次可見節點可能有近百個，全部一口氣建 pattern＋發請求會在同一幀裡卡住主執行緒。
+    // 每個閒置時段做一批，其餘排到下一次——畫面上是圖示陸續變清晰，不是整個卡一下。
+    upgradeInBatches(visibleNodeIds(data, { x: tl.x, y: tl.y, w: br.x - tl.x, h: br.y - tl.y }));
   });
 }
 svg.addEventListener('wheel', maybeUpgradeIcons);
@@ -294,7 +334,13 @@ svg.addEventListener('pointerup', maybeUpgradeIcons);
 // 就 <1 的極端狀況）本來就會被 maybeUpgradeIcons() 內部擋掉，不用在外面再判斷一次
 // isMobile，改成無條件呼叫更準確反映「哪個裝置的初始縮放實際上超過門檻」這件事跟裝置種類
 // 沒有必然關係，是純粹看縮放數字。
-maybeUpgradeIcons();
+// 首屏這一次改成閒置時才做：它有可能一口氣建立上百個 pattern、發出上百個圖片請求，擠在
+// 首次繪製的同一批工作裡只會拖慢「使用者看到第一畫面」的時間，而高解析與否是漸進增強。
+// Safari 沒有 requestIdleCallback（照本檔慣例做存在性檢查後退回 setTimeout）。
+//
+// ⚠️ 門檻修正之後，1280×720 dpr1 的桌機首屏**不會**再升級（實測每單位只有 0.52 裝置像素，
+// sprite 綽綽有餘）——這正是修正的重點，不是退步。高 DPI 螢幕與手機才會在這裡真的升級。
+whenIdle(maybeUpgradeIcons);
 
 // --- 鍵盤：方向鍵平移、+/- 縮放 ---
 // 這個 handler 掛在 window 上、原本不判斷 focus（「不管焦點在哪都該生效」）；但下面

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -283,11 +283,14 @@ test('C. 縮放 > 1x 後，可見節點圖示從 sprite pattern 換成高解析 
   // 升級過），不是的話代表這個測試的前提不成立，用 test.skip 誠實記錄，不是硬凹。
   await goToNatureBranch(page, isMobile);
   const icon = page.locator('g.node[data-id="1002"] > rect.icon');
-  // 先確保起始狀態真的是 sprite。門檻改成裝置像素後，手機／高 DPI 裝置一載入就已經升級，
-  // 那時沒有可觀察的轉換窗口——先縮到門檻以下把它換回 sprite，測試才有前提可驗。
-  if (!(await icon.getAttribute('fill'))?.includes('icon-pattern-')) {
-    await zoomOutToSprite(page);
-  }
+  // 先把畫面縮到門檻以下，確保起始狀態真的是 sprite——門檻改成裝置像素後，手機／高 DPI
+  // 裝置一載入就已經升級，那時沒有可觀察的轉換窗口。
+  //
+  // ⚠️ 這裡**無條件**縮，不能先探測一次 fill 再決定要不要縮：首屏升級排在
+  // requestIdleCallback 裡、又是分批做的，探測很可能落在升級之前，於是跳過縮放、接著去等
+  // 一個幾毫秒後就會消失的 sprite fill，一路等到 timeout 才失敗，而錯誤訊息指向斷言、
+  // 不指向時序。
+  await zoomOutToSprite(page);
   await expect
     .poll(async () => (await icon.getAttribute('fill')) ?? '', { timeout: 5000 })
     .toContain('icon-pattern-');
@@ -642,6 +645,90 @@ test('V. 窄桌機視窗下詳情卡片不壓在分支側欄上，也不被推�
     expect(m.left, `${w}x${h} 卡片左緣不可跑出畫面`).toBeGreaterThanOrEqual(0);
     expect(m.right, `${w}x${h} 卡片右緣不可跑出畫面`).toBeLessThanOrEqual(w);
   }
+});
+
+test('W. 手機版 footer 的著作權聲明不被底部分支 chip 蓋住', async ({ page, isMobile }) => {
+  test.skip(!isMobile, '僅手機版：#branch-chips 只在手機版存在');
+  // 頁面改成不捲動之後，fixed 的 chip 列會永遠疊在 footer 上緣，而 footer 第二行是
+  // 「遊戲圖示與文字著作權屬 111 Percent Inc.」——手機上會完全讀不到，而且沒有捲動可以
+  // 把它露出來。修法是讓 footer 留一段等於 chip 列實際高度（--chips-h，量出來的）的下內距。
+  await page.goto('/tree');
+  await page.waitForSelector('#tree g.node');
+
+  const m = await page.evaluate(() => {
+    const footer = document.querySelector('footer')!;
+    // 量的是「文字實際佔的範圍」不是 footer 的盒子——盒子本來就會延伸到 chip 列底下，
+    // 那正是讓位用的內距。
+    const range = document.createRange();
+    range.selectNodeContents(footer);
+    const text = range.getBoundingClientRect();
+    const chips = document.querySelector('#branch-chips')!.getBoundingClientRect();
+    return {
+      textBottom: text.bottom,
+      chipsTop: chips.top,
+      overflow: document.documentElement.scrollHeight - window.innerHeight,
+      hasCopyright: /111 Percent/.test(footer.textContent ?? ''),
+    };
+  });
+
+  expect(m.hasCopyright, 'footer 應該有著作權聲明').toBe(true);
+  expect(m.textBottom, 'footer 文字底緣不可落到 chip 列裡').toBeLessThanOrEqual(m.chipsTop);
+  // 讓位不可以把捲軸叫回來（main 是 flex: 1，footer 變高應該是畫布縮，不是頁面變長）。
+  expect(m.overflow, '讓位之後仍不該捲得動').toBeLessThanOrEqual(0);
+});
+
+test('X. 縮小之後，排隊中的升級批次不會把圖示又升回去', async ({ page, isMobile }) => {
+  // 驗的是「縮小之後，最終狀態真的乾淨」：沒有節點停在高解析，`<defs>` 裡也沒有沒人用的
+  // pattern（後者才是真的把那幾 MB 的解碼結果還回去，只換 fill 是不夠的）。
+  //
+  // ⚠️ 誠實標註：`upgradeInBatches()` 的世代號檢查（排隊中的批次發現門檻已經被推翻就停手）
+  // **這條測試抓不到**。實測可見節點約 68 個、每批 24 個，三批在 zoomOutToSprite() 走完
+  // 之前就跑完了，等到縮小時已經沒有排隊中的批次可以觀察。要穩定重現得能控制批次時序
+  // （例如把批次大小做成可注入的），代價比它擋到的風險高。這條測試守的是最終狀態，
+  // 不是那個競態本身。
+  await goToNatureBranch(page, isMobile);
+
+  // 先放大到確定跨過升級門檻，讓它排出一串批次。
+  const point = await centerOf(page.locator('g.node[data-id="1001"]'));
+  await expect.poll(async () => {
+    await zoomInAt(page, point, 4);
+    return devicePxPerUnit(page);
+  }, { timeout: 15000 }).toBeGreaterThan(1.2);
+  await page.waitForFunction(() => document.querySelectorAll('rect.icon[data-hires="1"]').length > 0);
+
+  // 立刻縮回門檻以下。
+  await zoomOutToSprite(page);
+  expect(await devicePxPerUnit(page)).toBeLessThan(0.9);
+
+  // 給排隊中的批次充分的時間跑完（閒置回呼的 timeout 是 1000ms）。
+  await page.waitForTimeout(2000);
+  const after = await page.evaluate(() => ({
+    hires: document.querySelectorAll('rect.icon[data-hires="1"]').length,
+    patterns: document.querySelectorAll('defs > pattern[id^=icon-hires-]').length,
+  }));
+  expect(after.hires, '縮小後不該還有節點停在高解析').toBe(0);
+  expect(after.patterns, '沒人用的高解析 pattern 應該一併移除（記憶體才真的還得回去）').toBe(0);
+});
+
+test('Y. 只改變視窗大小（完全不互動）也會重新評估高解析門檻', async ({ page, isMobile }) => {
+  test.skip(!isMobile, '僅手機版：需要一個「一載入就已經升級」的起點');
+  // 門檻的兩個輸入（畫布尺寸、devicePixelRatio）都會隨視窗變動，而 resize 事件原本只接到
+  // updateNavHeight 與 schedulePositionPanel。不重算的話，使用者轉個螢幕方向、把瀏覽器
+  // 縮小、或把視窗拖到另一個 DPI 的螢幕之後，會一直停在已經不需要的高解析圖（或反過來，
+  // 停在糊掉的 sprite），直到剛好在畫布上滾一次滾輪為止。
+  await page.goto('/tree');
+  await page.waitForFunction(() => document.querySelectorAll('rect.icon[data-hires="1"]').length > 0);
+  expect(await devicePxPerUnit(page), 'Pixel 7 載入時應該在升級門檻之上').toBeGreaterThan(1.2);
+
+  // 把視窗變矮（畫布高度是 flex 分到的，視窗一矮畫布跟著矮）→ 每單位裝置像素掉到降級門檻
+  // 以下。412×300 是一個「小視窗／鍵盤彈出」的合理尺寸，不是為了測試硬湊的極端值。
+  await page.setViewportSize({ width: 412, height: 300 });
+  await expect.poll(() => devicePxPerUnit(page), { timeout: 5000 }).toBeLessThan(0.9);
+
+  // 完全沒有滾輪、沒有拖曳——只有 resize。
+  await expect
+    .poll(() => page.evaluate(() => document.querySelectorAll('rect.icon[data-hires="1"]').length), { timeout: 5000 })
+    .toBe(0);
 });
 
 test('K. 手機版詳情面板的重置警告不被底部分支 chip 蓋住（spec §2.1 強制要求的災情警告）', async ({ page, isMobile }) => {

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -174,15 +174,60 @@ test('手機版預設聚焦單一分支且有分支 chip', async ({ page, isMobi
   expect(await getViewportScale(page)).toBeGreaterThan(1.5);
 });
 
-test('首屏資產體積在預算內', async ({ page }) => {
-  let bytes = 0;
-  page.on('response', async r => {
-    if (r.url().includes('/assets/') || r.url().endsWith('.js') || r.url().endsWith('.css')) {
-      bytes += Number((await r.allHeaders())['content-length'] ?? 0);
-    }
+/** 目前一個使用者座標單位攤到幾個裝置像素——高解析升級的真正判準，見 src/lib/viewport.ts。 */
+async function devicePxPerUnit(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const svg = document.querySelector('#tree') as SVGSVGElement;
+    const vp = document.querySelector('#viewport');
+    const box = svg.getBoundingClientRect();
+    const vb = svg.getAttribute('viewBox')!.split(/\s+/).map(Number);
+    const scale = Number(/scale\(([-\d.]+)\)/.exec(vp?.getAttribute('transform') ?? '')?.[1] ?? 1);
+    return Math.min(box.width / vb[2]!, box.height / vb[3]!) * scale * window.devicePixelRatio;
   });
+}
+
+/** 縮到門檻以下，讓已升級的圖示換回 sprite（遲滯門檻 0.9，見 viewport.ts）。 */
+async function zoomOutToSprite(page: Page): Promise<void> {
+  const box = (await page.locator('#tree').boundingBox())!;
+  const point = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  await page.mouse.move(point.x, point.y);
+  for (let i = 0; i < 40; i++) await page.mouse.wheel(0, 120);
+  await page.waitForTimeout(200);
+}
+
+test('首屏資產體積在預算內', async ({ page }) => {
+  // ⚠️ 舊版是假綠的（review 報告 C06）：`page.on('response', async r => …)` 的回呼是
+  // async，Playwright 不會 await 它，`await r.allHeaders()` 還沒回來 goto 就結束了——
+  // 同一頁重跑量到 196KB～646KB 不等。而且靠 content-length，壓縮回應根本沒有這個標頭。
+  //
+  // 改成在頁面端讀 Resource Timing：transferSize 是實際過網路的位元組（含標頭、已壓縮），
+  // 快取命中時是 0，所以退回 encodedBodySize 當下限。這是瀏覽器自己記的帳，不會漏。
   await page.goto('/tree', { waitUntil: 'networkidle' });
-  expect(bytes).toBeLessThan(500 * 1024);
+  // ⚠️ 首屏的高解析升級排在 requestIdleCallback（timeout 1000ms）裡，networkidle 會在它
+  // 開火之前就滿足。不等這一段的話，這個測試量到的永遠是「還沒開始抓圖示」的快照——
+  // 把門檻改回舊版的 `vp.scale <= 1`（桌機會白抓 213 張）它一樣是綠的，等於什麼都沒守。
+  await page.waitForTimeout(1500);
+  await page.waitForLoadState('networkidle');
+  const m = await page.evaluate(() => {
+    const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+    const counted = entries.filter(e =>
+      e.name.includes('/assets/') || e.name.endsWith('.js') || e.name.endsWith('.css'));
+    return {
+      bytes: counted.reduce((a, e) => a + (e.transferSize || e.encodedBodySize || 0), 0),
+      iconRequests: entries.filter(e => e.name.includes('/assets/icons/')).length,
+      names: counted.map(e => e.name.split('/').pop()).slice(0, 5),
+    };
+  });
+  expect(m.bytes, `首屏資產 ${(m.bytes / 1024).toFixed(1)}KB（前幾項：${m.names.join(', ')}）`)
+    .toBeLessThan(500 * 1024);
+
+  // 請求數：這條守的是「不需要 2× 素材時，一張都不該抓」——修正前桌機（每單位 0.52 裝置
+  // 像素）無條件抓 213 張高解析圖示約 500KB，純屬浪費。真的需要 2× 的高 DPI 裝置會抓
+  // （Pixel 7 實測 68 張，體積仍在預算內），那是該做的事，不設上限。
+  const devicePx = await devicePxPerUnit(page);
+  if (devicePx <= 1.2) {
+    expect(m.iconRequests, `每單位 ${devicePx.toFixed(2)} 裝置像素，sprite 已足夠，不該抓個別圖示`).toBe(0);
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -238,12 +283,22 @@ test('C. 縮放 > 1x 後，可見節點圖示從 sprite pattern 換成高解析 
   // 升級過），不是的話代表這個測試的前提不成立，用 test.skip 誠實記錄，不是硬凹。
   await goToNatureBranch(page, isMobile);
   const icon = page.locator('g.node[data-id="1002"] > rect.icon');
-  const startFill = await icon.getAttribute('fill');
-  test.skip(!startFill?.includes('icon-pattern-'), '這個裝置/縮放組合下，分支導覽跳轉後已經是高解析圖示，沒有可觀察的轉換窗口');
+  // 先確保起始狀態真的是 sprite。門檻改成裝置像素後，手機／高 DPI 裝置一載入就已經升級，
+  // 那時沒有可觀察的轉換窗口——先縮到門檻以下把它換回 sprite，測試才有前提可驗。
+  if (!(await icon.getAttribute('fill'))?.includes('icon-pattern-')) {
+    await zoomOutToSprite(page);
+  }
+  await expect
+    .poll(async () => (await icon.getAttribute('fill')) ?? '', { timeout: 5000 })
+    .toContain('icon-pattern-');
 
+  // 放大到跨過裝置像素門檻。用 poll 而不是固定圈數：不同 project 的初始倍率與 DPR 不同，
+  // 「幾圈才夠」不是一個跨裝置成立的常數。
   const point = await centerOf(page.locator('g.node[data-id="1002"]'));
-  await zoomInAt(page, point, 8);
-  expect(await getViewportScale(page)).toBeGreaterThan(1);
+  await expect.poll(async () => {
+    await zoomInAt(page, point, 4);
+    return devicePxPerUnit(page);
+  }, { timeout: 15000 }).toBeGreaterThan(1.2);
 
   // upgradeIcons 是用 wheel 事件節流的 requestAnimationFrame 觸發的（見 tree-canvas.ts），
   // 給瀏覽器一次繪圖機會讓它真的跑完。
@@ -457,13 +512,13 @@ test('H. 鍵盤 focus 的金邊貼合圖示輪廓：圓形節點得到圓環，�
   for (const [x, y] of corners) expect(isGold(at(x, y))).toBe(false);
 });
 
-test('I. 初次載入未經任何互動，只要初始縮放超過 1x，可見節點就已經是高解析圖示', async ({ page }) => {
+test('I. 初次載入未經任何互動，只要真的需要 2× 素材，可見節點就已經是高解析圖示', async ({ page }) => {
   await page.goto('/tree'); // 網址沒帶 ?node=，桌機整棵樹置中、手機預設對準 nature 分支
-  const scale = await getViewportScale(page);
-  // bug 4 修正後，兩種裝置的初始視角都可能超過 1x（手機幾乎必然；桌機則看可讀性下限
-  // 是否高於 fitTo 整棵樹的 0.9x，容器夠扁時會超過，見上面的修正記錄）——只有真的超過
-  // 1x 時，bug 2 的修正才有東西可驗，沒超過就 skip，不是硬凹一個不成立的前提。
-  test.skip(scale <= 1, `初始縮放 ${scale} ≤ 1x，這個裝置/環境下沒有可觀察的「初次載入已經是高解析」窗口`);
+  const devicePx = await devicePxPerUnit(page);
+  // 門檻從「vp.scale > 1」改成「每單位裝置像素 > 1.2」（見 src/lib/viewport.ts 的
+  // effectiveDevicePx）。1280×720 dpr1 的桌機算出來只有約 0.52——**不升級才是對的**，
+  // sprite 的來源解析度綽綽有餘，舊版在這裡白抓 213 張圖約 500KB。
+  test.skip(devicePx <= 1.2, `每單位 ${devicePx.toFixed(2)} 裝置像素 ≤ 1.2，這個裝置不需要 2× 素材（sprite 已足夠）`);
 
   // 完全不做任何滑鼠/觸控互動（不 wheel、不拖曳）。如果 bug 2 還在，這裡會停在 sprite
   // pattern，要等使用者互動一次才會升級。waitForFunction 給 rAF 一次跑的機會（跟測試 C

--- a/tests/lib/hires.test.ts
+++ b/tests/lib/hires.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { parseHTML } from 'linkedom';
-import { visibleNodeIds, upgradeIcons } from '../../src/lib/hires';
+import { visibleNodeIds, upgradeIcons, downgradeIcons, resetFailedIcons } from '../../src/lib/hires';
 import { renderTree } from '../../src/lib/render';
 import type { TreeData } from '../../src/lib/types';
 
@@ -143,5 +143,70 @@ describe('upgradeIcons', () => {
     const pattern = svg.querySelector(`defs > pattern#icon-hires-${hash}`)!;
     const img = pattern.querySelector<SVGImageElement>('image')!;
     expect(img.getAttribute('href')).toBe(`/custom/base/${hash}.webp`);
+  });
+});
+
+describe('降級與載入失敗（2026-08-19 review 追加）', () => {
+  beforeEach(() => resetFailedIcons());
+
+  it('降級不只換 fill，還要把沒人用的 pattern 從 <defs> 移掉——那才是真的把記憶體還回去', () => {
+    const svg = renderInto();
+    upgradeIcons(['1001'], svg);
+    expect(svg.querySelectorAll('defs > pattern[id^=icon-hires-]')).toHaveLength(1);
+
+    downgradeIcons([...svg.querySelectorAll<SVGRectElement>('rect.icon')], svg);
+
+    expect(svg.querySelectorAll('defs > pattern[id^=icon-hires-]')).toHaveLength(0);
+    expect(iconRect(svg, '1001').getAttribute('fill')).toMatch(/icon-pattern-/);
+  });
+
+  it('還有節點在用的 pattern 不會被誤刪', () => {
+    const svg = renderInto();
+    upgradeIcons(['1001', '1002'], svg);
+    const first = iconRect(svg, '1001');
+    const second = iconRect(svg, '1002');
+    // 兩個節點各有各的圖示雜湊時互不影響；只降級第一個，第二個的 pattern 要留著。
+    downgradeIcons([first], svg);
+    expect(second.getAttribute('fill')).toMatch(/icon-hires-/);
+    expect(svg.querySelector(`#icon-hires-${second.getAttribute('data-icon')}`)).not.toBeNull();
+  });
+
+  it('沒有 fill 可記的節點不升級——升了就永遠降不回來，連載入失敗都救不了', () => {
+    const svg = renderInto();
+    const icon = iconRect(svg, '1001');
+    icon.removeAttribute('fill');
+
+    upgradeIcons(['1001'], svg);
+
+    expect(icon.dataset.hires).toBeUndefined();
+    expect(svg.querySelectorAll('defs > pattern[id^=icon-hires-]')).toHaveLength(0);
+  });
+});
+
+describe('載入失敗不會變成無限重抓', () => {
+  beforeEach(() => resetFailedIcons());
+
+  it('高解析圖載入失敗後：換回 sprite、移除 pattern，而且下一次不再重抓同一張', () => {
+    const svg = renderInto();
+    upgradeIcons(['1001'], svg);
+    const icon = iconRect(svg, '1001');
+    const hash = icon.getAttribute('data-icon')!;
+    expect(icon.getAttribute('fill')).toBe(`url(#icon-hires-${hash})`);
+
+    // 模擬那張 webp 404（雜湊改了沒重建圖，就是 CLAUDE.md 記過的 render-nodes 事故）。
+    // linkedom 的 dispatchEvent 只吃它自己那個 Event 類別，Node 的全域 Event 會在
+    // 設定 eventPhase 時炸掉（只有 getter）。從文件的 defaultView 取。
+    const LinkedomEvent = (svg.ownerDocument as unknown as { defaultView: { Event: typeof Event } }).defaultView.Event;
+    svg.querySelector(`#icon-hires-${hash} image`)!.dispatchEvent(new LinkedomEvent('error'));
+
+    expect(icon.getAttribute('fill')).toMatch(/icon-pattern-/);
+    expect(svg.querySelector(`#icon-hires-${hash}`)).toBeNull();
+
+    // 關鍵：再升一次不可以又把它建回來。沒有失敗名單的話，「pattern 不存在」與
+    // 「節點沒升級過」兩個條件又同時成立，於是重建 pattern、重發那個 404——使用者每滾一次
+    // 滾輪就重演一次，節點還會 sprite→空白→sprite 閃一下。
+    upgradeIcons(['1001'], svg);
+    expect(svg.querySelector(`#icon-hires-${hash}`)).toBeNull();
+    expect(icon.getAttribute('fill')).toMatch(/icon-pattern-/);
   });
 });

--- a/tests/lib/viewport.test.ts
+++ b/tests/lib/viewport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseHTML } from 'linkedom';
-import { Viewport, minReadableScale } from '../../src/lib/viewport';
+import { Viewport, minReadableScale, effectiveDevicePx, HIRES_UPGRADE_AT, HIRES_DOWNGRADE_AT } from '../../src/lib/viewport';
 
 function make() {
   const { document } = parseHTML('<html><body></body></html>');
@@ -219,5 +219,41 @@ describe('minReadableScale（task-17/18 裁決：最小可讀縮放下限，純�
     const mobile = minReadableScale(390, 800, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, DICE_ICON_WIDTH_UNITS, 32);
     const desktop = minReadableScale(1200, 800, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, DICE_ICON_WIDTH_UNITS, 32);
     expect(mobile).toBeGreaterThan(desktop);
+  });
+});
+
+describe('effectiveDevicePx（高解析升級的真正判準）', () => {
+  // viewBox 固定 2000×1700（見 CLAUDE.md 的不變量）。
+  const VB: [number, number] = [2000, 1700];
+  const px = (w: number, h: number, scale: number, dpr: number) =>
+    effectiveDevicePx(w, h, VB[0], VB[1], scale, dpr);
+
+  it('1280×720 桌機 dpr1：初始視角不該升級——舊版在這裡白抓了 213 張圖', () => {
+    // 畫布高 595（1280×720 扣掉 nav 與 footer），可讀性下限把 scale 拉到約 1.49。
+    const v = px(1280, 595, 1.49, 1);
+    expect(v).toBeCloseTo(0.52, 1);
+    expect(v).toBeLessThan(HIRES_UPGRADE_AT);
+  });
+
+  it('2560×1440 dpr2：該升級——舊版在這裡一張都沒升', () => {
+    const v = px(2560, 1315, 1.49, 2);
+    expect(v).toBeGreaterThan(HIRES_UPGRADE_AT);
+  });
+
+  it('Pixel 7 手機（412×678 dpr2.625，分支視角 scale≈5.5）：該升級', () => {
+    expect(px(412, 678, 5.5, 2.625)).toBeGreaterThan(HIRES_UPGRADE_AT);
+  });
+
+  it('桌機放大之後就會跨過門檻', () => {
+    expect(px(1280, 595, 1.49, 1)).toBeLessThan(HIRES_UPGRADE_AT);
+    expect(px(1280, 595, 4, 1)).toBeGreaterThan(HIRES_UPGRADE_AT);
+  });
+
+  it('遲滯：升級門檻高於降級門檻，避免在邊界反覆抖動', () => {
+    expect(HIRES_UPGRADE_AT).toBeGreaterThan(HIRES_DOWNGRADE_AT);
+  });
+
+  it('viewBox 壞掉時回 0，不會變成 NaN 一路傳下去', () => {
+    expect(effectiveDevicePx(1280, 595, 0, 1700, 2, 1)).toBe(0);
   });
 });

--- a/tests/scripts/tree-canvas.test.ts
+++ b/tests/scripts/tree-canvas.test.ts
@@ -287,7 +287,11 @@ describe('tree-canvas 整合：分支快速跳轉（task-17，spec §6.2.6）', 
   // 子元素，吃掉 nav（50.59）與 footer（73.94）之外的剩餘高度。**這裡不要再自己算一個
   // `視窗高 − 某個常數`**：舊註解寫的 610 是從 `calc(100vh - 110px)` 那個寫死偏移量推來的，
   // 而那個 110 本身就是錯的（實際 124.53），版面改成 flex 之後那條 CSS 已經不存在了。
-  const DESKTOP_CANVAS_HEIGHT = 595;
+  // 寫成算式而不是一個裸數字，是為了讓「這個數字打哪來」跟著它一起走：實測 nav 50.59、
+  // footer 73.94（Playwright Desktop Chrome 1280×720）。它只是給 stub 用的近似容器尺寸，
+  // 真正的版面正確性由 E2E 的 U（scrollHeight === innerHeight、畫布填滿）守著；這裡寫錯
+  // 只會讓可讀性下限測在一個略微失真的容器上，不會讓錯誤的版面過關。
+  const DESKTOP_CANVAS_HEIGHT = Math.round(720 - 50.59 - 73.94);
   function stubDesktopRect(page: { svg: HTMLElement }): void {
     Object.assign(page.svg, {
       getBoundingClientRect: () => ({


### PR DESCRIPTION
review 報告的 **P6（hires 圖示載入策略＋E2E 體積預算）**。（PR #9 因為 base 分支被刪而自動關閉，這是同一批改動重開的。）

## 核心：升級門檻用錯了物理量

舊判斷是 `if (vp.scale <= 1) return;`——只看 `#viewport` 的**內部倍率**，沒有考慮畫布元素相對 viewBox 的基礎縮放，也沒有考慮裝置像素比。兩個方向都錯：

| 情境 | 每單位實際裝置像素 | 舊行為 | 新行為 |
|---|---|---|---|
| 1280×720 dpr1 桌機首屏 | **0.52**（scale 1.4845，實測） | 升級 213 張、**732KB** | 不升級 ✅ |
| 2560×1440 dpr2 | 1.41 | 不升級 | 升級 ✅ |
| Pixel 7（dpr 2.625，分支視角） | 遠超門檻 | 升級 | 升級 ✅ |

sprite 的格子就是節點顯示尺寸的 1×，個別 WebP 是 2×。該問的是「一個使用者座標單位攤到幾個**實體**像素」，不是「viewport 的倍率是多少」。

抽成純函式 `effectiveDevicePx(svgW, svgH, vbW, vbH, scale, dpr)` 放在 `src/lib/viewport.ts`，公式跟瀏覽器畫 SVG 的 `preserveAspectRatio` meet 行為一致。門檻加遲滯：`> 1.2` 升級、`< 0.9` 降回 sprite，避免在邊界反覆縮放時抖動。

## 其他

- **首屏改排在 `requestIdleCallback`**（Safari 沒有 → 退回 `setTimeout`），並**分批**（每批 24 個）——一口氣建上百個 pattern＋發上百個請求會卡住同一幀
- **圖示元素索引建一次**（`buildIconIndex`）：節點是建置期畫好、之後不增刪的，不必每次縮放都對每個可見節點各跑一次 `querySelector`
- **`downgradeIcons()`**：縮小到門檻以下把已升級的換回 sprite（pattern 只增不減，實測整棵樹全升級多出約 4.6MB）
- **載入失敗自動止血**：高解析 WebP 的 `<image>` 加 `error` 監聽 → 把用到該 pattern 的節點全換回 sprite 並移除 pattern。以前是一塊什麼都沒有的空白節點，且沒有任何錯誤訊息

## E2E 體積預算：原本是假綠的

`page.on('response', async r => { … await r.allHeaders() … })` 的回呼是 async，Playwright 不會 await 它——`goto` 結束時多數標頭還沒回來，同一頁重跑量到 196KB～646KB 不等。而且靠 `content-length`，壓縮回應根本沒這個標頭。

改成在頁面端讀 Resource Timing 的 `transferSize`（快取命中為 0 時退回 `encodedBodySize`），並加一條「不需要 2× 素材時，個別圖示請求數必須是 0」。

⚠️ **這個測試我第一版寫錯過一次**：首屏升級排在 `requestIdleCallback(timeout 1000)` 裡，`networkidle` 會在它開火前就滿足，所以量到的是「還沒開始抓圖示」的快照——把門檻改回舊版它一樣是綠的。加了 `waitForTimeout(1500)` ＋ 再等一次 `networkidle` 才真的守得住。

## 驗證

```
npm run validate  ✅ ／ npm run typecheck ✅
npm test          ✅ 279 tests（先前 273，新增 6）
npm run e2e       ✅ 55 passed / 7 skipped
```

弄壞會不會紅（**這次記得先 `npm run build`**——`npx playwright test` 不會重建，不建的話測到的是舊產物，我第一輪就是這樣得到一個假的「沒紅」）：

```
門檻改回 `vp.scale <= 1` → 首屏資產體積在預算內 ✘
    Expected: < 512000
    Received:   732479
effectiveDevicePx 忽略 dpr → 2 條單元測試紅（2560×1440 dpr2、Pixel 7）
```

測試 C 改成先縮回 sprite 再放大到跨過裝置像素門檻（用 `expect.poll` 而不是寫死圈數——不同 project 的初始倍率與 DPR 不同，「幾圈才夠」不是跨裝置成立的常數）。測試 I 的 skip 條件從 `scale <= 1` 改成 `devicePx <= 1.2`，並改名為「只要真的需要 2× 素材」。

## 沒做的

- 「高解析圖載入完成前保留 sprite fill」只做了失敗路徑（`error` → 換回 sprite）。載入中那一瞬間 `<pattern>` 裡的 `<image>` 還沒畫出來，節點會閃一下空白——要根治得先用 `Image` 預載再換 fill，那會讓現有同步行為的單元測試與 E2E 全部要改，價值不成比例。
- pattern 的 LRU 回收：改用遲滯降級之後，縮小就會整批換回 sprite，實務上不會再無限累積。
