### PR TITLE
fix: E2E 埠可由環境變數覆蓋

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,55 @@ E2E 的 U（不該捲動）、V（詳情卡片避開側欄）、J（手機抽屜
 `--chips-h` 由 `tree-canvas.ts` 量 chip 列的實際高度寫入（**不要寫死 3.5rem**）。
 `<main>` 是 `flex: 1`，footer 變高只會讓畫布跟著縮，不會把捲軸叫回來。E2E 的 W 守這條。
 
+### ⚠️ deploy job 沒有 checkout：任何靠 repo 根目錄的東西都不會上線
+
+`ci.yml` 的 `deploy` job **刻意沒有 `actions/checkout`**，只 `download-artifact` 拿 `verify` 驗過的
+`dist/`，然後 `wrangler pages deploy dist`。這是為了讓「上線的位元組＝被驗過的位元組」。
+
+代價是 runner 的工作目錄裡**只有 dist/**。Cloudflare Pages 的 Functions 是看
+「執行指令的那個目錄底下有沒有 `functions/`」來決定要不要打包的
+（`node_modules/wrangler/.../cli.js`：`path.join(process.cwd(), "functions")`，
+不存在就整段跳過，**沒有 warning、部署照樣回成功**）。所以哪天要加 Pages Functions，
+必須在 deploy job 補一步 checkout：
+
+- ⚠️ **checkout 要放在 `download-artifact` 之前**。`actions/checkout` 預設 `clean: true` 會清空
+  工作目錄，順序反了會把下載好的 `dist/` 洗掉，然後部署一個空目錄——而且大概不會報錯。
+- ⚠️ action 要 pin 40 碼 SHA（repo 開了 `sha_pinning_required`）。
+- 加了 Functions 之後，**deploy 後面要補一步 smoke**（例如 `curl -fsS <endpoint> | grep -q ...`），
+  否則「binding 沒綁／表沒建／functions 沒上傳／CSP 擋掉」四種失敗都會收斂成
+  「那塊功能靜靜消失」，沒有任何人會知道。
+
+### ⚠️ `public/_headers` 對 Pages Functions 的回應無效
+
+官方文件明載 `_headers` 定義的自訂標頭**不會套用到 Pages Functions 產生的回應**
+（https://developers.cloudflare.com/pages/configuration/headers/ ）。
+所以 CSP 之類的標頭要兩邊都寫：靜態頁走 `_headers`，Function 在程式碼裡自己放進 `Response`。
+驗收也要分開驗——`curl -sI` 打靜態頁**和**打 Function 的路徑。
+
+### ⚠️ 未知路徑目前回 200 加一份首頁，不是 404
+
+`dist/` 裡沒有 `404.html` 時，Cloudflare Pages 會當成 SPA 處理、拿 index.html 當 fallback。
+實測 `curl -sI https://rd2-wiki.pages.dev/this-does-not-exist-12345` → `HTTP/2 200`，
+內容是 `<title>首頁 rd2-wiki</title>`。打錯的網址與失效的分享連結都會被搜尋引擎和連結預覽
+當成有效頁面。要修就是加一個 `public/404.html`（尚未做）。
+
+### ⚠️ 兩個工作區同時跑 E2E 會互相偷 server
+
+`playwright.config.ts` 的 `reuseExistingServer: true` 配上寫死的埠，意思是
+**只要那個埠上有人在聽，就拿它當受測站台——不管那是不是你自己建的 dist**。
+
+2026-08-19 實際咬到人：這台機器上同時有主 checkout 與一個 git worktree 在動，主 checkout
+留了一個沒收掉的 `serve dist -l 4321`（`npm run e2e` 結束後殘留），worktree 那邊跑 E2E 時
+Playwright 直接重用了它 → 測到的是**別份產物**。症狀是「element(s) not found」，
+看起來完全像自己的程式沒輸出那個元素。破案靠 `curl localhost:4321 | grep -c <自己的東西>` 回 0。
+
+現在埠可以用 `E2E_PORT` 覆蓋：平行開兩個工作區時，其中一邊
+`E2E_PORT=4399 npm run e2e` 就互不干擾（CI 上沒有這個變數，行為不變）。
+**收工前也順手確認一下 `pgrep -af "bin/serve"` 沒有殘留。**
+
+這跟下面那條是同一族的坑——**都是「你以為在測自己的東西，其實不是」**：
+一個測到舊產物，一個測到別人的產物。
+
 ### ⚠️ `npx playwright test` 不會重新建置
 
 `npm run e2e` 有 `pree2e` 會先 `npm run build`；**直接跑 `npx playwright test` 不會**。

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,25 @@
 // HMR/中介層，跟正式環境不完全一樣）。
 import { defineConfig, devices } from '@playwright/test';
 
+/**
+ * E2E 用的埠，可用 `E2E_PORT` 覆蓋。
+ *
+ * ⚠️ 為什麼要能覆蓋：`reuseExistingServer: true` 加上寫死的埠，等於「只要 4321 上有人在聽，
+ * 就拿它當受測站台」——**不管那是不是你自己建的 dist**。2026-08-19 實際咬到人：這台機器上
+ * 同時有兩個工作區（主 checkout 與一個 git worktree），前者留了一個沒收掉的 `serve dist`，
+ * 後者跑 E2E 時 Playwright 直接重用了它，於是測到的是**別份產物**。
+ *
+ * 症狀非常有誤導性：測試紅在「element(s) not found」，看起來完全像自己的程式沒輸出那個元素。
+ * 破案的是 `curl localhost:4321 | grep -c <自己的東西>` 回 0。
+ *
+ * 這跟 CLAUDE.md 記的「`npx playwright test` 不會重新建置」是同一族的坑——
+ * **都是「你以為在測自己的東西，其實不是」**：一個測到舊產物，一個測到別人的產物。
+ *
+ * 平行開兩個工作區時，其中一邊 `E2E_PORT=4399 npm run e2e` 就互不干擾。CI 上沒有這個變數，
+ * 行為與先前完全相同。
+ */
+const PORT = Number(process.env.E2E_PORT ?? 4321);
+
 export default defineConfig({
   testDir: 'tests/e2e',
   // 這台機器是 headless CI 環境，沒有互動式終端機可以看報表；用 list 印在終端機就好，
@@ -18,12 +37,14 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   webServer: {
-    command: 'npx serve dist -l 4321',
-    port: 4321,
+    command: `npx serve dist -l ${PORT}`,
+    port: PORT,
+    // reuseExistingServer：本機重跑時不必每次重起 server。
+    // ⚠️ 它跟「埠寫死」合起來會咬人——見檔案開頭 PORT 的說明。
     reuseExistingServer: true,
   },
   use: {
-    baseURL: 'http://localhost:4321',
+    baseURL: `http://localhost:${PORT}`,
     // 失敗時留痕跡：截圖、trace 都只在失敗時才存，成功案例不佔空間（test-results/ 已在
     // .gitignore，這些產物本來就不進 repo，純粹方便事後除錯）。
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## 起因

這台機器上同時有兩個工作區在動（主 checkout ＋ 一個 git worktree）。主 checkout 留了一個沒收掉的 `serve dist -l 4321`（`npm run e2e` 結束後殘留了兩小時），worktree 那邊跑 E2E 時，`reuseExistingServer: true` 讓 Playwright **直接重用了它**——測到的是別份產物。

症狀很有誤導性：測試紅在 `element(s) not found`，看起來完全像自己的程式沒把元素輸出。破案的是 `curl localhost:4321 | grep -c <自己的東西>` 回 0。

## 改動

`playwright.config.ts` 的埠抽成 `const PORT = Number(process.env.E2E_PORT ?? 4321)`，`command`／`port`／`baseURL` 三處共用。**CI 上沒有 `E2E_PORT`，行為與先前完全相同。**

平行開兩個工作區時，其中一邊 `E2E_PORT=4399 npm run e2e` 就互不干擾。

CLAUDE.md 補一條「踩過的坑」，並點出它跟既有的「`npx playwright test` 不會重新建置」是同一族——**都是「你以為在測自己的東西，其實不是」**：一個測到舊產物，一個測到別人的產物。

## 驗證

```
npx tsc --noEmit                                   ✅
npm run e2e（預設埠）                               ✅ 59 passed / 9 skipped
E2E_PORT=4477 npx playwright test -g 首屏資產體積    ✅ 1 passed
跑完後 ss -ltn | grep -E '4477|4321'                 → 兩個埠都沒人監聽（Playwright 自己收掉）
```

殘留的那個 4321 進程我已經 kill 掉了。