### PR TITLE
feat: 首頁訪客計數器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ public/assets/
 src/generated/
 test-results/
 playwright-report/
+# wrangler pages dev 的本機狀態（含本機 D1），只在本機 smoke 時產生
+.wrangler/
 diff-summary.md
 diff-summary.json
 comment.md

--- a/functions/api/hits.ts
+++ b/functions/api/hits.ts
@@ -23,10 +23,16 @@ function ok(n: number): Response {
   return new Response(JSON.stringify({ n }), { status: 200, headers: HEADERS });
 }
 
-/** 錯誤一律回固定字串。錯誤訊息含 SQL 與 key 名，這是公開端點，不能吐出去。 */
-function fail(status: number, err: unknown): Response {
+/**
+ * 錯誤一律回固定字串。錯誤訊息含 SQL 與 key 名，這是公開端點，不能吐出去。
+ *
+ * code 只有兩個值、都不洩漏任何東西，但要分開：403 是「你被擋了」、500 是「我壞了」。
+ * 全部回 internal 的話，線上除錯時分不出「Sec-Fetch-Site 判斷把真實訪客誤擋」
+ * 和「資料庫真的掛了」——兩者的處理方式完全不同。
+ */
+function fail(status: number, code: 'forbidden' | 'internal', err?: unknown): Response {
   if (err !== undefined) console.error('[hits]', err);
-  return new Response('{"error":"internal"}', { status, headers: HEADERS });
+  return new Response(JSON.stringify({ error: code }), { status, headers: HEADERS });
 }
 
 /**
@@ -45,11 +51,11 @@ function isCrossSite(request: Request): boolean {
 }
 
 export async function onRequestPost(ctx: HitsContext): Promise<Response> {
-  if (isCrossSite(ctx.request)) return fail(403, undefined);
+  if (isCrossSite(ctx.request)) return fail(403, 'forbidden');
   try {
     return ok(await bumpCounter(ctx.env.DB, COUNTER_KEY));
   } catch (err) {
-    return fail(500, err);
+    return fail(500, 'internal', err);
   }
 }
 
@@ -57,6 +63,6 @@ export async function onRequestGet(ctx: HitsContext): Promise<Response> {
   try {
     return ok(await readCounter(ctx.env.DB, COUNTER_KEY));
   } catch (err) {
-    return fail(500, err);
+    return fail(500, 'internal', err);
   }
 }

--- a/functions/api/hits.ts
+++ b/functions/api/hits.ts
@@ -1,0 +1,62 @@
+// /api/hits 的 Pages Function。刻意保持薄——邏輯在 functions/lib/counter.ts。
+// 薄殼有自己的測試（tests/functions/hits.test.ts），因為方法分派與 binding 名字
+// 只存在這個檔案裡，counter.ts 的測試碰不到它們。
+//
+// ⚠️ 檔名決定路由：functions/api/hits.ts → /api/hits。
+// 同目錄下沒有匯出 onRequest* 的檔案不會變成路由（實測確認，官方文件對此沉默）。
+import { bumpCounter, readCounter, COUNTER_KEY, type D1Like } from '../lib/counter';
+
+interface HitsContext {
+  request: Request;
+  env: { DB: D1Like };
+}
+
+// _headers 不會套用到 Pages Functions 產生的回應（官方文件明載），所以標頭只能在這裡放。
+// no-store 目前其實是多餘的（Cloudflare CDN 預設不快取 JSON、也不快取非 GET），
+// 純粹是日後有人加 Cache Rule 或掛自訂網域時的保險。
+const HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+};
+
+function ok(n: number): Response {
+  return new Response(JSON.stringify({ n }), { status: 200, headers: HEADERS });
+}
+
+/** 錯誤一律回固定字串。錯誤訊息含 SQL 與 key 名，這是公開端點，不能吐出去。 */
+function fail(status: number, err: unknown): Response {
+  if (err !== undefined) console.error('[hits]', err);
+  return new Response('{"error":"internal"}', { status, headers: HEADERS });
+}
+
+/**
+ * 擋跨站 drive-by。
+ *
+ * 這個 endpoint 同源、不需要 CORS，所以任何第三方網頁都能用
+ * fetch(..., { mode: 'no-cors' }) 在它自己每一位訪客的瀏覽器裡替我們 +1——
+ * 那是分散在真實 IP 上的流量，IP 節流完全無效。
+ *
+ * 標頭不存在時放行：舊瀏覽器不送 Sec-Fetch-Site，擋掉它們等於擋掉真實訪客，
+ * 而這道防線本來就只是提高門檻，不是安全邊界。
+ */
+function isCrossSite(request: Request): boolean {
+  const site = request.headers.get('Sec-Fetch-Site');
+  return site !== null && site !== 'same-origin' && site !== 'none';
+}
+
+export async function onRequestPost(ctx: HitsContext): Promise<Response> {
+  if (isCrossSite(ctx.request)) return fail(403, undefined);
+  try {
+    return ok(await bumpCounter(ctx.env.DB, COUNTER_KEY));
+  } catch (err) {
+    return fail(500, err);
+  }
+}
+
+export async function onRequestGet(ctx: HitsContext): Promise<Response> {
+  try {
+    return ok(await readCounter(ctx.env.DB, COUNTER_KEY));
+  } catch (err) {
+    return fail(500, err);
+  }
+}

--- a/functions/lib/counter.ts
+++ b/functions/lib/counter.ts
@@ -1,0 +1,53 @@
+// 訪客計數器的純邏輯。刻意不知道 HTTP——薄殼（functions/api/hits.ts）負責那一層。
+//
+// ⚠️ 這個檔案在 Cloudflare Workers（workerd）上執行，不是在瀏覽器裡。
+// 但專案的 tsconfig 帶著 lib.dom 檢查它（functions/ 併進主 tsconfig 的 include，
+// 為的是零新依賴、typecheck 不必跑兩次），所以在這裡寫 document.querySelector(...)、
+// localStorage、XMLHttpRequest 全部都編得過、上線才炸。
+// 只有標準 Web API（fetch/Request/Response/URL）在 workerd 上真的存在。
+//
+// ⚠️ 專案開了 noUncheckedIndexedAccess／noUnusedLocals／noUnusedParameters，
+// 解構 D1 查詢結果（res.results[0].n）會噴 TS2532「Object is possibly 'undefined'」。
+// 那不是設定壞掉，是刻意開的嚴格檢查。
+
+/**
+ * D1 用得到的最小介面，自己宣告而不是裝 @cloudflare/workers-types。
+ *
+ * 理由：Workers types 的 Response／fetch／Headers 會跟站台的 DOM lib 打架，
+ * 而分成兩個 tsconfig 又要讓 `npm run typecheck` 跑兩次。這裡只用到 D1 的一小塊，
+ * 自己宣告的成本遠低於那兩個代價。
+ */
+export interface D1Like {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      first<T>(colName: string): Promise<T | null>;
+    };
+  };
+}
+
+/** 目前只有一列。日後要分頁計數就多幾個 key。 */
+export const COUNTER_KEY = 'total';
+
+// ⚠️ RETURNING 是「實作支援但未文件化」的依賴：Cloudflare 的 D1 文件從頭到尾沒提過它
+// （整份文件語料比對零次命中，只寫「compatible with most SQLite's SQL convention」）。
+// 實測可用，但這代表它可能在沒有公告的情況下改變行為——部署後的 curl smoke 是唯一
+// 守得住這件事的東西。
+//
+// 用單一 statement 而不是「SELECT 再 UPDATE」：D1 每個資料庫是單執行緒、一次處理一個
+// 查詢，單一 statement 的遞增不會掉數；拆成兩句就會有讀-改-寫的競態。
+const SQL_BUMP = 'UPDATE hits SET n = n + 1 WHERE k = ?1 RETURNING n';
+const SQL_READ = 'SELECT n FROM hits WHERE k = ?1';
+
+/** 遞增並回傳**遞增後**的值——所以回傳值天然就是「這位訪客的序號」。 */
+export async function bumpCounter(db: D1Like, key: string): Promise<number> {
+  const n = await db.prepare(SQL_BUMP).bind(key).first<number>('n');
+  if (n === null) throw new Error(`計數器沒有這一列，建表 SQL 的 seed 可能沒跑到：k=${key}`);
+  return n;
+}
+
+/** 只讀，不遞增。 */
+export async function readCounter(db: D1Like, key: string): Promise<number> {
+  const n = await db.prepare(SQL_READ).bind(key).first<number>('n');
+  if (n === null) throw new Error(`計數器沒有這一列，建表 SQL 的 seed 可能沒跑到：k=${key}`);
+  return n;
+}

--- a/functions/schema.sql
+++ b/functions/schema.sql
@@ -1,0 +1,12 @@
+-- 訪客計數器的資料表。部署時用：
+--   wrangler d1 execute <db-name> --remote --file=functions/schema.sql
+-- ⚠️ --remote 一定要加。--local 與 --remote 都沒有預設值，兩個都不給會走本機 sqlite，
+-- 建表看起來成功、真正的 D1 一張表都沒有，而且不會有任何錯誤訊息。
+--
+-- 只有一列。刻意不存訪客識別、不存 IP、不存 User-Agent。
+-- k 是預留的分類鍵（日後要分頁計數就多幾列），目前只有 'total'。
+CREATE TABLE IF NOT EXISTS hits (
+  k TEXT PRIMARY KEY,
+  n INTEGER NOT NULL DEFAULT 0
+);
+INSERT OR IGNORE INTO hits (k, n) VALUES ('total', 0);

--- a/src/lib/hit-counter.ts
+++ b/src/lib/hit-counter.ts
@@ -1,0 +1,83 @@
+// 前端唯一知道「訪客號碼從哪來」的檔案。index.astro 只負責顯示，不知道後端是誰——
+// 之後要換後端、加「今日／總計」，都只動這一支。
+//
+// 回傳 null = 顯示不出來，呼叫端據此隱藏整塊。刻意不區分失敗原因：
+// 對訪客來說「數字出不來」就是同一件事，而區分原因會讓呼叫端跟著長出分支。
+
+/** ⚠️ 必須是相對路徑。寫成絕對網址會在自訂網域下變成跨源請求，就得處理 CORS 與 preflight。 */
+export const HIT_ENDPOINT = '/api/hits';
+
+export const HIT_STORAGE_KEY = 'rd2-wiki:hit';
+
+/** 弱網下 Promise 可能永遠不 settle，隱藏那條路徑就永遠不會執行。 */
+const TIMEOUT_MS = 3000;
+
+export interface HitCounterDeps {
+  fetch?: typeof globalThis.fetch;
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+}
+
+/**
+ * sessionStorage 的存取**本身**會丟例外（Safari 無痕、Firefox 封鎖所有 cookie、
+ * iframe 的第三方儲存限制會丟 SecurityError），所以每次存取都要各自包起來。
+ * 取不到就當「沒有快取」，不是「失敗」——快取只是省一次請求，不是必要條件。
+ */
+function readCached(storage: HitCounterDeps['storage']): number | null {
+  try {
+    const raw = storage?.getItem(HIT_STORAGE_KEY);
+    if (raw === null || raw === undefined) return null;
+    const n = Number(raw);
+    return Number.isInteger(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCached(storage: HitCounterDeps['storage'], n: number): void {
+  try {
+    storage?.setItem(HIT_STORAGE_KEY, String(n));
+  } catch {
+    // 寫不進去只是下次會重新取號，不影響這次顯示。
+  }
+}
+
+/** 連 sessionStorage 這個屬性本身的存取都可能丟例外，不只是它的方法。 */
+function safeSessionStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 取得這位訪客的號碼。
+ *
+ * ⚠️ 成功與否**不能靠 status code 判斷**。實測線上站：dist/ 裡沒有 404.html 時，
+ * Cloudflare Pages 把未知路徑當 SPA，GET 未知路徑會回 200 加一份完整的首頁 HTML；
+ * 而 functions 沒被部署時 POST 回的是 405 不是 404。唯一可靠的判準是 payload 形狀。
+ */
+export async function fetchHitNumber(deps: HitCounterDeps = {}): Promise<number | null> {
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const storage = deps.storage === undefined ? safeSessionStorage() : deps.storage;
+
+  const cached = readCached(storage);
+  if (cached !== null) return cached;
+
+  try {
+    const res = await doFetch(HIT_ENDPOINT, {
+      method: 'POST',
+      cache: 'no-store',
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    const n = (body as { n?: unknown } | null)?.n;
+    if (typeof n !== 'number' || !Number.isInteger(n)) return null;
+    writeCached(storage, n);
+    return n;
+  } catch {
+    // 網路錯誤、AbortError（逾時）、CSP 擋下、回應不是合法 JSON，全部走這裡。
+    return null;
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,5 +15,33 @@ import data from '../generated/tree.json';
     <p style="color:var(--muted)">
       遊戲版本v{data.meta.gameVersion} ・ 資料版本 {data.meta.gameBundle}（更新於 {data.meta.updated}）
     </p>
+
+    <!-- 訪客計數器。
+         ⚠️ 刻意放在現有的 section 元素裡面，而不是自成一個新的：tests/e2e/tree.spec.ts
+         的 T 用 page.locator('section') 讀首頁，頁面上多一個 section 會讓那條測試以
+         Playwright strict mode violation 紅掉。
+         預設 hidden，拿到數字才顯示——但 hidden 在 global.css 裡被改成
+         visibility: hidden（保留高度），所以顯示與否都不會讓下面的 footer 跳動。 -->
+    <p id="hit-counter" hidden>
+      你是第<span id="hit-number"></span>位訪客
+    </p>
   </section>
 </Base>
+
+<script>
+  // 數字只能在瀏覽器端取得：站台是 output: 'static'，頁面在建置期產生、由邊緣快取送出，
+  // render 的時候不可能知道「這次訪問」。
+  import { fetchHitNumber } from '../lib/hit-counter';
+
+  const block = document.getElementById('hit-counter');
+  const slot = document.getElementById('hit-number');
+  if (block && slot) {
+    fetchHitNumber().then(n => {
+      // null = 顯示不出來（endpoint 不在、逾時、CSP 擋下、儲存被拒……）。
+      // 一律保持 hidden，不顯示 0，也不留一個空的數字框。
+      if (n === null) return;
+      slot.textContent = n.toLocaleString('en-US');
+      block.removeAttribute('hidden');
+    });
+  }
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -224,3 +224,43 @@ pre {
 #detail.kw-clickable .kw:hover {
   text-decoration: underline;
 }
+
+/*
+ * 首頁訪客計數器（S2：金色等寬數字）。
+ *
+ * 只用既有變數，不新增 CSS 變數也不新增字型檔——--gold 已經是全站唯一的強調色
+ * （連結、前置鏈高亮都是它），等寬字型堆疊 code/pre 早就定義過。
+ *
+ * ⚠️ 失敗時用 visibility 而不是 display: none。display: none 會把已經佔好位的區塊
+ * 收掉、footer 往上跳，而「失敗」是 astro dev、E2E、以及 deploy job 補上 checkout 之前
+ * 的線上環境的預設狀態——等於幾乎每次載入都會位移一下。保留高度，成功與失敗兩條路徑
+ * 版面才一致。
+ */
+#hit-counter {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+#hit-counter[hidden] {
+  /* [hidden] 預設是 display: none，這裡蓋掉它——理由見上面。 */
+  display: block;
+  visibility: hidden;
+}
+
+#hit-number {
+  display: inline-block;
+  margin: 0 0.4rem;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--gold);
+  /* 等寬數字：數值變動時字寬不變，版面不會左右抽動。 */
+  font-variant-numeric: tabular-nums;
+  /* 數字回填前先把位子撐開，填進去的那一刻不會位移。 */
+  min-width: 6ch;
+}

--- a/tests/e2e/hit-counter.spec.ts
+++ b/tests/e2e/hit-counter.spec.ts
@@ -1,0 +1,79 @@
+// 首頁訪客計數器的端對端測試。
+//
+// 代號用 HC 前綴而不是延續 tree.spec.ts 的單字母序列：那邊 A–Y 已經用完，
+// 而且這是獨立的功能檔，用自己的前綴在 CI 紅燈時更容易一眼指認。
+//
+// ⚠️ 這三條都靠 page.route 攔截 /api/hits。E2E 環境（npx serve dist）本來就沒有
+// Pages Functions，所以「沒攔到」的後果是走真實的 404 → 三條都會以「數字出不來」
+// 的形式紅掉，而不是靜靜通過。HC1 另外明確斷言 route 真的被呼叫過。
+import { test, expect } from '@playwright/test';
+
+test('HC1. 取到號碼時顯示「你是第 N 位訪客」', async ({ page }) => {
+  let called = 0;
+  await page.route('**/api/hits', async route => {
+    called += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ n: 1234 }),
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.locator('#hit-counter')).toBeVisible();
+  // 千分位由 toLocaleString('en-US') 產生，不是自己拼的字串。
+  await expect(page.locator('#hit-number')).toHaveText('1,234');
+  expect(called).toBe(1);
+});
+
+test('HC2. 端點掛掉時不顯示數字，而且版面高度不變', async ({ page }) => {
+  // 失敗是 astro dev、E2E、以及 deploy job 補上 checkout 之前的線上環境的預設狀態，
+  // 所以這條路徑的版面穩定性比成功路徑更重要——display:none 會讓下面的內容往上跳。
+  await page.route('**/api/hits', route => route.fulfill({ status: 405, body: '' }));
+
+  await page.goto('/');
+  const block = page.locator('#hit-counter');
+  await expect(block).toBeHidden();
+  // 保留高度、只是看不見。boundingBox 為 null 或高度 0 就代表被 display:none 收掉了。
+  const box = await block.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThan(0);
+  await expect(page.locator('#hit-number')).toHaveText('');
+});
+
+test('HC3. 回 200 但內容是 HTML 時也不顯示', async ({ page }) => {
+  // dist/ 沒有 404.html 時 Cloudflare Pages 把未知路徑當 SPA，回 200 加一份首頁。
+  // 靠 status code 判斷的話這會被當成功，畫面上會出現 NaN 或 undefined。
+  //
+  // ⚠️ 這條守的是「res.json() 解析失敗」那條路徑，不是 payload 形狀檢查——
+  // HTML 餵給 json() 會直接拋錯走 catch。抽查證實：把形狀檢查整段拿掉，這條仍然綠。
+  // 守形狀檢查的是 HC4。
+  await page.route('**/api/hits', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><title>x</title>',
+    }),
+  );
+
+  await page.goto('/');
+  await expect(page.locator('#hit-counter')).toBeHidden();
+});
+
+test('HC4. 回合法 JSON 但 n 是字串時也不顯示', async ({ page }) => {
+  // 跟 HC3 走的是不同路徑：這裡 res.json() 會成功，擋下來的是 payload 的**型別**檢查。
+  //
+  // ⚠️ 情境刻意選「n 是字串」而不是「沒有 n 欄位」。缺欄位的話，即使把檢查退化成
+  // `n === undefined` 也還是攔得住，這條測試就守不到東西——實測過，那樣改壞它仍然是綠的。
+  // 型別錯才會穿過退化後的檢查：字串 "1234" 有 toLocaleString()，會被當成數字顯示出來。
+  await page.route('**/api/hits', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ n: '1234' }),
+    }),
+  );
+
+  await page.goto('/');
+  await expect(page.locator('#hit-counter')).toBeHidden();
+});

--- a/tests/functions/counter.test.ts
+++ b/tests/functions/counter.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+// ⚠️ 不能寫 `import { DatabaseSync } from 'node:sqlite'`。
+// Node 24 刻意不把 'sqlite' 列進 module.builtinModules（它只能用 node: 前綴存取），
+// 而 vite 用那份清單判斷什麼是內建模組——於是它把 'node:sqlite' 剝成 'sqlite'、
+// 當成 npm 套件去找，然後整個測試檔以「Failed to load url sqlite」collect 失敗。
+// 用 createRequire 讓載入發生在執行期，vite 的靜態分析就碰不到它。
+const nodeRequire = createRequire(import.meta.url);
+const { DatabaseSync } = nodeRequire('node:sqlite') as {
+  DatabaseSync: new (path: string) => DatabaseSyncLike;
+};
+
+/** node:sqlite 沒有隨附型別宣告，這裡只宣告用得到的部分。 */
+interface DatabaseSyncLike {
+  exec(sql: string): void;
+  prepare(sql: string): { get(...params: unknown[]): unknown };
+}
+import { bumpCounter, readCounter, COUNTER_KEY, type D1Like } from '../../functions/lib/counter';
+
+/**
+ * 用真的 SQLite 而不是假物件。
+ *
+ * 假物件不解析 SQL，餵什麼 SQL 都回同一個 canned 值——那樣把 `SET n = n + 1` 改成
+ * `SET n = n`、把 key 打錯、或整個拿掉 `RETURNING n`，測試都不會紅，等於沒有防線。
+ * Node 24 內建 node:sqlite，用它就不必新增任何依賴。
+ *
+ * ⚠️ 這裡只保證 SQL 的 SQLite 語意正確。D1 的 client API 行為（.bind().first() 的簽章、
+ * 無列時回 null）靠 wrangler pages dev 的手動 smoke 驗，不是這支測試的責任。
+ */
+function toD1(db: DatabaseSyncLike): D1Like {
+  return {
+    prepare: (sql: string) => ({
+      bind: (...values: unknown[]) => ({
+        first: async <T>(colName: string): Promise<T | null> => {
+          const row = db.prepare(sql).get(...(values as string[])) as
+            | Record<string, unknown>
+            | undefined;
+          if (row === undefined) return null;
+          const v = row[colName];
+          return v === undefined ? null : (v as T);
+        },
+      }),
+    }),
+  };
+}
+
+let db: DatabaseSyncLike;
+let d1: D1Like;
+
+beforeEach(() => {
+  db = new DatabaseSync(':memory:');
+  db.exec(readFileSync('functions/schema.sql', 'utf8'));
+  d1 = toD1(db);
+});
+
+describe('bumpCounter', () => {
+  it('每呼叫一次就真的 +1，且回傳的是遞增後的值', async () => {
+    expect(await bumpCounter(d1, COUNTER_KEY)).toBe(1);
+    expect(await bumpCounter(d1, COUNTER_KEY)).toBe(2);
+    expect(await bumpCounter(d1, COUNTER_KEY)).toBe(3);
+  });
+
+  it('回傳值真的來自資料庫，不是自己算的', async () => {
+    await bumpCounter(d1, COUNTER_KEY);
+    // 繞過 counter.ts 直接查表——兩邊對得起來才代表 RETURNING 真的有回值。
+    const row = db.prepare('SELECT n FROM hits WHERE k = ?').get(COUNTER_KEY) as { n: number };
+    expect(row.n).toBe(1);
+  });
+
+  it('key 不存在時拋錯，而且錯誤訊息帶得出是哪個 key', async () => {
+    // 這是「忘記跑建表 SQL 的 seed」的唯一外部訊號。靜默回 0 的話，
+    // 線上會看到一個永遠停在 0 的計數器，卻沒有任何地方會紅。
+    await expect(bumpCounter(d1, 'nope')).rejects.toThrow(/nope/);
+  });
+});
+
+describe('readCounter', () => {
+  it('讀得到目前的值，而且不會把值加上去', async () => {
+    await bumpCounter(d1, COUNTER_KEY);
+    await bumpCounter(d1, COUNTER_KEY);
+    expect(await readCounter(d1, COUNTER_KEY)).toBe(2);
+    expect(await readCounter(d1, COUNTER_KEY)).toBe(2);
+    const row = db.prepare('SELECT n FROM hits WHERE k = ?').get(COUNTER_KEY) as { n: number };
+    expect(row.n).toBe(2);
+  });
+
+  it('key 不存在時拋錯', async () => {
+    await expect(readCounter(d1, 'nope')).rejects.toThrow(/nope/);
+  });
+});

--- a/tests/functions/hits.test.ts
+++ b/tests/functions/hits.test.ts
@@ -55,6 +55,8 @@ describe('onRequestPost', () => {
     const res = await onRequestPost(ctx('POST', db, { 'Sec-Fetch-Site': 'cross-site' }));
     expect(res.status).toBe(403);
     expect(sqls).toHaveLength(0);
+    // 403 要說 forbidden 不能說 internal：線上除錯時得分得出「訪客被誤擋」和「資料庫掛了」。
+    expect(await res.text()).toBe('{"error":"forbidden"}');
   });
 
   it('沒有 Sec-Fetch-Site 標頭時放行（舊瀏覽器不送這個標頭）', async () => {

--- a/tests/functions/hits.test.ts
+++ b/tests/functions/hits.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { onRequestGet, onRequestPost } from '../../functions/api/hits';
+import type { D1Like } from '../../functions/lib/counter';
+
+/**
+ * 假的 D1：記錄收到的 SQL，讓測試能斷言「GET 沒有寫、POST 有寫」。
+ *
+ * 這裡用假物件是對的——薄殼的責任是分派與組回應，不是 SQL 正確性
+ * （那個由 counter.test.ts 用真的 SQLite 守）。但它必須記下 SQL，
+ * 否則「把 onRequestGet 接到 bumpCounter」這種錯誤不會紅。
+ */
+function fakeDb(n = 42): { db: D1Like; sqls: string[] } {
+  const sqls: string[] = [];
+  return {
+    sqls,
+    db: {
+      prepare: (sql: string) => {
+        sqls.push(sql);
+        return { bind: () => ({ first: async <T>() => n as T }) };
+      },
+    },
+  };
+}
+
+function ctx(method: string, db: D1Like, headers: Record<string, string> = {}) {
+  return {
+    request: new Request('https://rd2-wiki.pages.dev/api/hits', { method, headers }),
+    env: { DB: db },
+  };
+}
+
+describe('onRequestPost', () => {
+  it('回 {"n": 數字}，而且真的走遞增那條 SQL', async () => {
+    const { db, sqls } = fakeDb(1234);
+    const res = await onRequestPost(ctx('POST', db, { 'Sec-Fetch-Site': 'same-origin' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ n: 1234 });
+    expect(sqls.join()).toContain('UPDATE');
+  });
+
+  it('帶 Cache-Control: no-store', async () => {
+    // _headers 對 Pages Functions 的回應無效，標頭只能由 Function 自己放。
+    const { db } = fakeDb();
+    const res = await onRequestPost(ctx('POST', db, { 'Sec-Fetch-Site': 'same-origin' }));
+    // 要一併斷言 200：錯誤回應也帶這個標頭，少了這行的話「binding 名字打錯 → 一律 500」
+    // 這種壞法在這條測試底下仍然是綠的。
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('跨站來的 POST 一律拒絕，而且不會寫進資料庫', async () => {
+    // 這個 endpoint 不需要 CORS 就能被別的網站用 mode:'no-cors' 驅動——
+    // 那是分散在真實 IP 上的流量，IP 節流完全擋不住。
+    const { db, sqls } = fakeDb();
+    const res = await onRequestPost(ctx('POST', db, { 'Sec-Fetch-Site': 'cross-site' }));
+    expect(res.status).toBe(403);
+    expect(sqls).toHaveLength(0);
+  });
+
+  it('沒有 Sec-Fetch-Site 標頭時放行（舊瀏覽器不送這個標頭）', async () => {
+    const { db } = fakeDb(7);
+    const res = await onRequestPost(ctx('POST', db));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ n: 7 });
+  });
+
+  it('資料庫拋錯時回 500，而且不把錯誤內容吐給客戶端', async () => {
+    // 錯誤訊息含 SQL 與 key 名，是公開端點，不能直接回出去。
+    const db: D1Like = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            throw new Error('UPDATE hits SET n = n + 1 WHERE k = ?1 秘密細節');
+          },
+        }),
+      }),
+    };
+    const res = await onRequestPost(ctx('POST', db, { 'Sec-Fetch-Site': 'same-origin' }));
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toBe('{"error":"internal"}');
+    expect(body).not.toContain('UPDATE');
+  });
+});
+
+describe('onRequestGet', () => {
+  it('回目前的值，而且走的是唯讀那條 SQL（不可以是 UPDATE）', async () => {
+    // 把 onRequestGet 接到 bumpCounter 是很容易犯的錯，而且線上完全看不出來——
+    // 只會讓數字被爬蟲的 GET 灌大。
+    const { db, sqls } = fakeDb(99);
+    const res = await onRequestGet(ctx('GET', db));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ n: 99 });
+    expect(sqls.join()).toContain('SELECT');
+    expect(sqls.join()).not.toContain('UPDATE');
+  });
+});

--- a/tests/lib/hit-counter.test.ts
+++ b/tests/lib/hit-counter.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchHitNumber, HIT_ENDPOINT, HIT_STORAGE_KEY } from '../../src/lib/hit-counter';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** 每次都是全新的假 storage，測試之間不互相污染。 */
+function memStorage(initial?: string) {
+  const map = new Map<string, string>();
+  if (initial !== undefined) map.set(HIT_STORAGE_KEY, initial);
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+describe('fetchHitNumber 的成功路徑', () => {
+  it('用 POST 打相對路徑 /api/hits', async () => {
+    // method 與 URL 都要斷言：把 POST 改成 GET 的話線上症狀是「數字從此凍結」，
+    // 看起來完全正常，沒有這條斷言不會有任何地方紅。
+    // 相對路徑同樣要守——寫成絕對網址會在自訂網域下變成跨源請求。
+    // 參數要明寫：vi.fn 的實作沒宣告參數的話，TypeScript 會把 mock.calls 推斷成空 tuple，
+    // 下面取 calls[0][1] 就會是 TS2493／TS2352。
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse({ n: 1234 }));
+    const storage = memStorage();
+    expect(await fetchHitNumber({ fetch: fetchMock as never, storage })).toBe(1234);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/hits');
+    expect(HIT_ENDPOINT).toBe('/api/hits');
+    expect(init?.method).toBe('POST');
+  });
+
+  it('把拿到的號碼寫進 storage', async () => {
+    // 不驗寫入的話，刪掉 setItem 這行也不會紅，而線上症狀是同一個分頁每次進首頁都 +1。
+    const storage = memStorage();
+    await fetchHitNumber({ fetch: (async () => jsonResponse({ n: 88 })) as never, storage });
+    expect(storage._map.get(HIT_STORAGE_KEY)).toBe('88');
+  });
+
+  it('storage 已經有號碼時直接用它，完全不打 API', async () => {
+    const fetchMock = vi.fn();
+    expect(await fetchHitNumber({ fetch: fetchMock as never, storage: memStorage('55') })).toBe(55);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchHitNumber 的失敗路徑（一律回 null）', () => {
+  it('200 但 body 是 HTML → null', async () => {
+    // 這是實際會發生的情況，不是假想：dist/ 沒有 404.html 時，Cloudflare Pages
+    // 把未知路徑當 SPA，回 200 + 整份首頁 HTML。靠 status code 判斷會把它當成功。
+    const html = new Response('<!doctype html><title>首頁</title>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html' },
+    });
+    expect(
+      await fetchHitNumber({ fetch: (async () => html) as never, storage: memStorage() }),
+    ).toBeNull();
+  });
+
+  it('200 但 JSON 沒有 n（或 n 不是數字）→ null', async () => {
+    const bad = async () => jsonResponse({ count: 5 });
+    expect(await fetchHitNumber({ fetch: bad as never, storage: memStorage() })).toBeNull();
+    const bad2 = async () => jsonResponse({ n: '5' });
+    expect(await fetchHitNumber({ fetch: bad2 as never, storage: memStorage() })).toBeNull();
+  });
+
+  it('405（functions 沒被部署時線上的真實回應）→ null', async () => {
+    const res = async () => new Response('', { status: 405 });
+    expect(await fetchHitNumber({ fetch: res as never, storage: memStorage() })).toBeNull();
+  });
+
+  it('fetch 直接拋錯 → null', async () => {
+    const boom = async () => {
+      throw new TypeError('Failed to fetch');
+    };
+    expect(await fetchHitNumber({ fetch: boom as never, storage: memStorage() })).toBeNull();
+  });
+
+  it('storage 讀取本身丟例外時不會炸掉整個函式，仍然打 API 取號', async () => {
+    // Safari 無痕、Firefox 封鎖所有 cookie、iframe 的第三方儲存限制都會讓
+    // getItem 直接丟 SecurityError。若這一行沒被包住，整段 script 當場爆掉，
+    // 連隱藏都跑不到，畫面留下一個空的佔位框。
+    const hostile = {
+      getItem: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+      setItem: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    };
+    const n = await fetchHitNumber({
+      fetch: (async () => jsonResponse({ n: 3 })) as never,
+      storage: hostile,
+    });
+    expect(n).toBe(3);
+  });
+
+  it('storage 是 null（環境完全沒有 sessionStorage）時仍然可用', async () => {
+    expect(
+      await fetchHitNumber({ fetch: (async () => jsonResponse({ n: 9 })) as never, storage: null }),
+    ).toBe(9);
+  });
+
+  it('傳給 fetch 的 init 帶 signal 與 cache: no-store', async () => {
+    // 沒有 timeout 的話，弱網下 Promise 永遠不 settle，隱藏那條路徑不會執行。
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse({ n: 1 }));
+    await fetchHitNumber({ fetch: fetchMock as never, storage: memStorage() });
+    const init = fetchMock.mock.calls[0]![1];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect(init?.cache).toBe('no-store');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "include": [
     "src",
     "tools",
-    "tests"
+    "tests",
+    "functions"
   ]
 }


### PR DESCRIPTION
首頁底部顯示「你是第 N 位訪客」，數字來自自架的 Cloudflare D1，不經第三方。

原本選的是 GoatCounter，實測後推翻：EasyPrivacy（uBlock Origin 預設啟用）收錄了
`||gc.zgo.at^$third-party` 與 `||goatcounter.com^$third-party`，連自訂網域 CNAME 都被
AdGuard 追蹤。裝了擋廣告的訪客會既不被算到、也看不到數字，而且沒有繞法。同網域 endpoint
是唯一不受封鎖名單影響的做法。

## 這個 PR 還不能合併

`ci.yml` 的 deploy job 沒有 `actions/checkout`，只 `download-artifact` 拿 `dist`，
所以 repo 根的 `functions/` 到不了 runner。wrangler 找不到就整段跳過，**不出警告、
部署照樣回成功**——合進去會得到一個永久 405 的 endpoint 而 CI 全綠。

需要先在 deploy job 補：
- `actions/checkout`（**必須放在 `download-artifact` 之前**，checkout 預設會清空工作目錄）
- 部署後的 smoke：`curl -fsS -X POST <url>/api/hits | grep -q '"n"'`

## 驗證

- 單元 304 passed（+21）、E2E 67 passed / 9 skipped（+8）、validate ✅、typecheck exit 0
- 每個模組都做過 mutation 抽查：把實作改壞確認測試真的會紅
- 用真的 workerd（`wrangler pages dev` + 本機 D1）跑過端對端：
  POST 遞增、GET 不遞增、跨站 POST 403 且不遞增、DELETE 405、無表時 500

## 設計要點

- 遞增用單一 statement `UPDATE ... RETURNING n`（D1 單執行緒，不會掉數）
- 前端判斷成功**不看 status code**，看 payload 形狀——因為 `dist/` 沒有 404.html 時
  Pages 把未知路徑當 SPA，GET 未知路徑回的是 200 加一整份首頁 HTML
- 失敗時保留區塊高度（不是 `display:none`），避免版面位移
- `functions/` 併進主 tsconfig 的 include，不裝 `@cloudflare/workers-types`（會跟 DOM lib 打架）

設計與部署文件在本機 `docs/`（未進版控），已鏡像 Samba。