### PR TITLE
fix: deploy 取出 repo 讓 Functions 打包得到

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,20 @@ jobs:
           else
             echo "ready=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: 取出 repo（Pages Functions 要從工作目錄打包）
+        # ⚠️ **這一步必須排在 download-artifact 之前**：actions/checkout 預設 `clean: true`
+        # 會清空工作目錄，順序反了會把下載好的 dist/ 洗掉，然後部署一個空目錄——
+        # 而且 wrangler 大概不會報錯。
+        #
+        # 為什麼需要它：Cloudflare Pages 的 Functions 是看「執行指令的那個目錄底下有沒有
+        # functions/」來決定要不要打包的（wrangler 內部是 path.join(process.cwd(), "functions")），
+        # **不存在就整段跳過，沒有 warning、部署照樣回成功**。這個 job 原本刻意不做 checkout
+        # （只拿 verify 驗過的 dist），代價就是 repo 根的 functions/ 永遠到不了 runner。
+        #
+        # 這裡只取原始碼、不跑 npm ci：Functions 由 wrangler 內建的 esbuild 打包，
+        # 而 dist/ 仍然來自下一步的 artifact——**上線的靜態產物依舊是被驗過的那一份**。
+        if: steps.creds.outputs.ready == 'true'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: 取回 verify 驗過的建置產物
         # 刻意不在這裡重建：要上線的就是通過 validate／效能預算／單元測試／E2E 的那一份 dist。
         if: steps.creds.outputs.ready == 'true'


### PR DESCRIPTION
為 #14（首頁訪問計數器）鋪路。**這個 PR 要先進去，#14 才部署得出 `functions/`。**

## 問題

`deploy` job 原本刻意沒有 `actions/checkout`——只 `download-artifact` 拿 `verify` 驗過的 `dist/`，這樣「上線的位元組＝被驗過的位元組」。

代價是 runner 的工作目錄裡只有 `dist/`。而 Cloudflare Pages 的 Functions 是看**執行指令的那個目錄**底下有沒有 `functions/`：

```js
// wrangler 內部
const functionsDirectory = customFunctionsDirectory || path.join(process.cwd(), "functions");
if (!_workerJS && fs.existsSync(functionsDirectory)) { ... buildFunctions ... }
```

沒有 else、沒有 warning——**目錄不存在就整段跳過，部署照樣回成功**。官方文件也是這個說法：「if a `functions` folder exists **where the command is run**, that folder will be uploaded」。

## 改動

在 `download-artifact` **之前**插一步 `actions/checkout`。

⚠️ 順序不能反：`actions/checkout` 預設 `clean: true` 會清空工作目錄，放在後面會把下載好的 `dist/` 洗掉，然後部署一個空目錄——而且大概不會報錯。

不跑 `npm ci`：Functions 由 wrangler 內建的 esbuild 打包。**`dist/` 仍然來自 artifact，上線的靜態產物依舊是被驗過的那一份。**

## 對現況的影響：無

main 目前沒有 `functions/`，所以這個 PR 合進去之後 wrangler 的行為與先前完全相同（一樣跳過 Functions 打包）。真正的效果要等 #14 進來才看得到。

## ⚠️ smoke 步驟刻意不放在這個 PR

#14 的作者建議部署後補一步

```
curl -fsS -X POST https://rd2-wiki.pages.dev/api/hits | grep -q '"n"'
```

我很贊成——它能一次擋掉 binding 沒綁／表沒建／functions 沒上傳／CSP 擋掉四種失敗，而那四種都會收斂成「首頁那塊靜靜消失」，沒有這一步沒人會知道。

但**現在加會讓 main 的 CI 直接紅**：endpoint 還不存在。正確順序是

1. 這個 PR（checkout）→ merge
2. #14（functions/ 本體）→ merge，此時部署才真的帶上 Functions
3. 另開一個小 PR 加 smoke → 從那次之後每次部署都守著

第 3 步我會在 #14 進去之後開。

## 驗證

```
yaml 解析 → deploy 步驟順序：
  檢查部署憑證 → 取出 repo → 取回 verify 驗過的建置產物 → 部署到 Cloudflare Pages
所有 action 已 pin 40 碼 SHA（repo 開了 sha_pinning_required，寫 @v4 會被直接拒跑）
```

⚠️ 這個 PR 本身**驗不到**「Functions 真的被打包上去」——main 上還沒有 `functions/`。真正的驗證是 #14 merge 之後那次 main 部署，以及第 3 步的 smoke。