### PR TITLE
docs: 記下 banner 原始碼與門面素材規矩

### DIFF
--- a/.github/media/banner.src.html
+++ b/.github/media/banner.src.html
@@ -1,0 +1,53 @@
+<!doctype html><meta charset="utf-8">
+<!--
+  README 頂部 banner 的原始碼（產物：banner.webp，1280×640）。
+
+  需要兩個不進版控的檔案放在同一層：
+    banner.bg.png     用 Playwright 截 /tree 的畫布當底圖——選一個節點讓前置鏈亮起來
+                      （2004 原子骰子，滾輪縮放 3 段），再用 addStyleTag 把
+                      #detail,#toolbar,#branch-nav,#tree-controls,#site-nav,footer,#branch-chips
+                      設成 display:none，只留畫布。viewport 1440×900、deviceScaleFactor 2。
+    SpaceGrotesk.ttf  curl -sfL -o SpaceGrotesk.ttf \
+                        'https://raw.githubusercontent.com/google/fonts/main/ofl/spacegrotesk/SpaceGrotesk%5Bwght%5D.ttf'
+
+  產圖：Playwright 開這個檔（viewport 1280×640、deviceScaleFactor 2）截圖，再
+    sharp(png).resize({width:1280}).webp({quality:86}) → .github/media/banner.webp
+
+  ⚠️ 不要在 banner 裡放節點數之類會隨資料改動的數字——圖過期沒有任何檢查擋得住。
+  文案沿用 src/layouts/Base.astro 的 OG_TITLE / DESCRIPTION，不要在這裡另寫一份。
+-->
+<style>
+  @font-face{font-family:'Disp';src:url('./SpaceGrotesk.ttf') format('truetype');font-weight:100 900}
+  *{margin:0;padding:0;box-sizing:border-box}
+  html,body{width:1280px;height:640px;overflow:hidden}
+  body{background:#2f2942;font-family:'Noto Sans TC','Noto Sans CJK TC',sans-serif;color:#f7f3ff;position:relative}
+  .bg{position:absolute;inset:0;
+      background:url('./banner.bg.png') 26% 58% / 128% no-repeat;
+      filter:saturate(1.2) brightness(.95)}
+  .veil{position:absolute;inset:0;background:linear-gradient(100deg,
+        rgba(47,41,66,.985) 0%, rgba(47,41,66,.972) 34%,
+        rgba(47,41,66,.80) 50%, rgba(47,41,66,.34) 68%, rgba(47,41,66,.20) 100%)}
+  .vig{position:absolute;inset:0;box-shadow:inset 0 0 190px 60px rgba(24,20,36,.62)}
+  .wrap{position:relative;height:100%;display:flex;flex-direction:column;justify-content:center;
+        gap:20px;padding:0 0 0 86px;max-width:800px}
+  .mark{display:flex;align-items:baseline;gap:18px}
+  h1{font-family:'Disp','Noto Sans TC',sans-serif;font-size:98px;line-height:.95;font-weight:700;
+     letter-spacing:-.035em;color:#ffd66f;text-shadow:0 6px 30px rgba(0,0,0,.5)}
+  .tag{font-family:'Disp',sans-serif;font-size:15px;font-weight:600;letter-spacing:.22em;
+       text-transform:uppercase;color:#c3b8e6;border:1px solid #5c5286;border-radius:999px;
+       padding:6px 14px;background:rgba(50,43,75,.7)}
+  .sub{font-family:'Disp','Noto Sans TC','Noto Sans CJK TC',sans-serif;font-size:28px;font-weight:600;color:#f2ecff;letter-spacing:.005em}
+  .lede{font-size:19px;line-height:1.8;color:#cfc7e8;max-width:640px}
+  .url{font-family:"Disp",sans-serif;font-size:17px;letter-spacing:.08em;color:#b4a9d6;margin-top:16px}
+  .pills{display:flex;gap:11px;margin-top:8px}
+  .pill{font-size:16px;font-weight:600;padding:8px 18px;border-radius:999px;
+        border:1px solid #5c5286;background:rgba(50,43,75,.85);color:#efe9ff}
+  .pill b{font-family:'Disp',sans-serif;color:#ffd66f;font-weight:700}
+</style>
+<div class="bg"></div><div class="veil"></div><div class="vig"></div>
+<div class="wrap">
+  <div class="mark"><h1>rd2-wiki</h1><span class="tag">Fan made</span></div>
+  <div class="sub">Random Dice 2 骰子樹攻略站</div>
+  <div class="lede">Random Dice 2 骰子樹非官方玩家攻略站：<br>收錄全部節點、解鎖條件與前置關係。</div>
+  <div class="url">rd2-wiki.pages.dev</div>
+</div>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,34 @@ Playwright 直接重用了它 → 測到的是**別份產物**。症狀是「ele
   → 這類行為只能靠 E2E 驗
 - 臨時的 Playwright 腳本要放在 **repo 目錄下**才 import 得到 `@playwright/test`
 
+## README 與門面素材
+
+README 是產品頁形式（banner ＋ 徽章 ＋ `> [!WARNING]` 免責 ＋ 分讀者章節），對標
+`github.com/moeru-ai/airi`。2026-08-19 PR #17／#18。
+
+- 素材在 **`.github/media/`**：`banner.webp`（1280×640）、`screenshot-tree.webp`、
+  `screenshot-mobile.webp`，外加 banner 的原始碼 **`banner.src.html`**（重產所需的兩個輸入與
+  指令寫在該檔開頭的註解裡）。**不要放進 `public/`**——那會被打包進站台，還要吃規則 12 的效能預算。
+- ⚠️ **banner 裡不要放節點數這類會隨資料改動的數字**。第一版烤了「239 節點／248 條連線」，
+  2026-08-19 拿掉：資料 PR 一改數字，圖就會說謊，而 CI 完全擋不住。會變的事實只放文字。
+- banner 與 tagline 的文案**沿用 `src/layouts/Base.astro` 的 `OG_TITLE`／`DESCRIPTION`**
+  （連結預覽那組），不維護第二份。
+- 已知限制與 `src/lib/flags.ts` 的暫停功能**刻意不寫進 README**——那是維護者資訊，留在這份檔案。
+- ⚠️ **不要用 `[/about](/about)` 這種 root-relative 連結**：GitHub 會把它連到 `github.com/about`。
+  README 與 `CONTRIBUTING.md`（會被 `about.astro` import）都要寫完整網址，站台端一樣正常。
+- ⚠️ `LICENSE` 尾端有「MIT 只涵蓋程式碼」的附註 → GitHub 判成 `license.key = "other"`，
+  shields 的動態 license 徽章顯示 *not identifiable by github*。徽章已改成靜態的，
+  **不要為了讓徽章好看去刪那段附註**。
+- **推上去之前先在本機看渲染結果**（不是想像）：
+
+  ```bash
+  jq -Rs '{text:., mode:"gfm", context:"NatsuYukiowob/rd2-wiki"}' README.md > /tmp/md.json
+  gh api -X POST /markdown --input /tmp/md.json > /tmp/readme.html
+  # 套 github-markdown-css 後用 Playwright 截 fullPage，light/dark 各一張
+  ```
+
+  這樣抓到過上面那條 root-relative 連結與失效的 license 徽章——兩個都是純讀 Markdown 看不出來的。
+
 ## 不進版控
 
 `docs/`（規格書、實作計畫、部署步驟、已知問題）**刻意移出版控**，只留本機，


### PR DESCRIPTION
把 README banner 的原始碼收進 `.github/media/banner.src.html`（重產步驟寫在檔頭註解），並在 CLAUDE.md 補一節〈README 與門面素材〉：素材放哪、banner 不准放會過期的數字、文案沿用 `Base.astro` 的 OG 字串、root-relative 連結與 LICENSE 判定兩個坑、推上去前用 GitHub markdown API 在本機驗版面的做法。