### PR TITLE
tools: run the CLI entry point on Windows too

### DIFF
--- a/tools/add-icon.ts
+++ b/tools/add-icon.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { readPngSize } from './lib/png.js';
@@ -39,7 +40,7 @@ export function addIcon(srcPath: string, iconsDir: string): AddIconResult {
   return { hash, fileName, destPath, alreadyExists };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const src = process.argv[2];
   if (!src) {
     console.error('用法: npm run add-icon -- <圖片路徑>');

--- a/tools/build-data.ts
+++ b/tools/build-data.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { gzipSync } from 'node:zlib';
 import sharp from 'sharp';
 import { parseTree, COORD_TOLERANCE } from './lib/svg-parse.js';
@@ -159,7 +160,7 @@ export function buildTreeData(svgText: string, opts: BuildOpts): TreeData {
   };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const svgText = readFileSync('data/dice-tree.svg', 'utf8');
   const keywords = JSON.parse(readFileSync('data/keywords.json', 'utf8'));
   const unlockExceptions = JSON.parse(readFileSync('data/unlock-exceptions.json', 'utf8'));

--- a/tools/diff-summary.ts
+++ b/tools/diff-summary.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import type { TreeData } from '../src/lib/types.js';
 
 /**
@@ -283,7 +284,7 @@ export function buildDiffSummary(base: TreeData, head: TreeData): string {
   return renderDiffComment(computeDiff(base, head));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const [basePath, headPath] = [process.argv[2], process.argv[3]];
   if (!basePath || !headPath) {
     console.error('用法: npx tsx tools/diff-summary.ts <base.json> <head.json>');

--- a/tools/normalize-svg.ts
+++ b/tools/normalize-svg.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { loadSvg } from './lib/dom.js';
 
 const f = (n: number) => n.toFixed(2);
@@ -122,7 +123,7 @@ export function normalizeSvg(svgText: string): string {
   return doc.toString();
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const file = process.argv[2] ?? 'data/dice-tree.svg';
   writeFileSync(file, normalizeSvg(readFileSync(file, 'utf8')));
   console.log(`normalized ${file}`);

--- a/tools/split-svg.ts
+++ b/tools/split-svg.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { loadSvg } from './lib/dom.js';
 
@@ -23,7 +24,7 @@ export function splitSvg(svgText: string): SplitResult {
 //
 // 來源檔是遊戲原圖，**不在版控內**（各自放在自己機器上）。以前這裡有一個指向維護者本機的
 // 預設路徑：對別人來說那只會變成一個看不懂的 ENOENT，而且那條路徑不該出現在公開 repo 裡。
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const SRC = process.argv[2];
   if (!SRC) {
     console.error('用法：npm run split -- <遊戲原圖 SVG 的路徑>');

--- a/tools/validate.ts
+++ b/tools/validate.ts
@@ -1,4 +1,5 @@
 import { readFileSync, readdirSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { parseTree, splitTitleLevel, COORD_TOLERANCE } from './lib/svg-parse.js';
@@ -445,7 +446,7 @@ export function validate(svgText: string, opts: ValidateOpts): ValidateResult {
   return { errors, warnings };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const { errors, warnings } = validate(readFileSync('data/dice-tree.svg', 'utf8'), {
     keywords: JSON.parse(readFileSync('data/keywords.json', 'utf8')),
     upgradeCostTable: JSON.parse(readFileSync('data/upgrade-cost.json', 'utf8')),


### PR DESCRIPTION
Not from an existing issue — I hit this trying to set up for #24/#25/#26 and it looked worth fixing on its own.

## The bug

All six scripts in `tools/` end with:

```ts
if (import.meta.url === `file://${process.argv[1]}`) {
```

That comparison is **false on Windows**. `argv[1]` is a backslash path while `import.meta.url` is a `file:///C:/...` URL, so the body never runs and the script exits 0 having done nothing.

Measured, not inferred:

```
import.meta.url  : file:///C:/.../build-data.ts
argv[1]          : C:\...\build-data.ts
template compare : false
pathToFileURL    : file:///C:/.../build-data.ts
pathToFileURL cmp: true
```

## What it costs

`npm run build:data` prints its two banner lines and produces nothing — `src/generated/tree.json` is never written. Everything downstream then fails, and none of the failures point at the cause:

| command | before |
|---|---|
| `npm run build:data` | prints the banner, writes nothing, **exit 0** |
| `npm run build` | ✗ `Could not resolve "../generated/tree.json" from "src/pages/index.astro"` |
| `npm run typecheck` | ✗ `TS2307: Cannot find module '../generated/tree.json'` |
| `npm test` | ✗ 7 test files fail to collect, 1 test fails |
| `npm run validate` | **exits 0 without validating anything** |

That last row is why I thought this was worth its own PR rather than a note. `validate` is a gate, and on Windows it has been passing without looking at anything. `diff-summary.ts` has the same shape and is used by CI.

## The fix

`pathToFileURL(...).href` is the portable comparison. It is **identical** to the template form on POSIX — which is exactly why CI has never caught this.

`?? ''` because strict TS types `argv[1]` as `string | undefined` and `pathToFileURL` rejects `undefined`; without it `npm run typecheck` reports TS2345 on all six files.

## After, same machine, nothing else changed

```
npm run build:data   tree.json 119.6 KB, sprite 130 KB
                     tree.json gzip 18.9 KB / 20 KB，餘裕 1.1 KB
                     sprite.webp 129.9 KB / 400 KB，餘裕 270.1 KB
npm run validate     ✅ 驗證通過
npm run typecheck    clean
npm test             26 files, 337 tests, all passing
npm run build        3 page(s) built
```

## What I have not verified

**I have only reproduced this on Windows.** On macOS and Linux the two forms agree, so this should be a no-op there, but that is reasoning rather than a run — worth a second pair of eyes rather than my word for it. Your CI will settle it.

I would also understand if you would rather not carry a Windows fix for a platform you do not develop on. In that case a line in `CONTRIBUTING.md` saying the toolchain is POSIX-only would be more honest than the current silent pass, and I am happy to send that instead.
