### PR TITLE
test: 釘住 tools 的 CLI entry guard 寫法

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,29 @@ Playwright 直接重用了它 → 測到的是**別份產物**。症狀是「ele
 失敗長相：正本留著指向已被 `rmSync` 刪掉的舊圖示雜湊，`npm run validate` 爆出 239 個
 規則 7(a) 錯誤，而完全看不出是哪一步說了謊。
 
+### ⚠️ CLI entry guard：`file://${process.argv[1]}` 是壞的，一律用 `pathToFileURL`
+
+`tools/` 的六支腳本都靠一行 guard 判斷「我是被直接執行、還是被 import」。舊寫法
+`import.meta.url === \`file://${process.argv[1]}\`` 在 Windows 上恆為 false（`argv[1]` 是
+反斜線路徑，`import.meta.url` 是 `file:///C:/...`），腳本會印完 banner 就 exit 0 什麼都沒做。
+最貴的是 `npm run validate`：**它是閘門，卻在 Windows 上一直「通過」而沒有驗任何東西**。
+
+POSIX 也不是安全的：`import.meta.url` 會 percent-encode，template literal 不會，所以
+checkout 路徑只要含空白或非 ASCII（`~/我的專案/`）就踩到同一個空跑。CI 沒抓到純粹是因為
+runner 的路徑剛好是純 ASCII。
+
+正確寫法只有一種，`tests/tools/entry-guard.test.ts` 會掃過 `tools/*.ts` 釘住它：
+
+```ts
+import { pathToFileURL } from 'node:url';
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+```
+
+`?? ''` 是因為 `noUncheckedIndexedAccess` 把 `argv[1]` 型別成 `string | undefined`；
+`pathToFileURL('')` 會解析成 cwd 的 URL 而不是丟例外，guard 單純不成立，是安全的預設。
+
+外部貢獻者 dchaudhari7177 在 PR #34 找到並修掉（2026-08-20，`9aa098d`）。
+
 ### Playwright 的 `omitBackground` 只拿掉「頁面」的背景
 
 用 Chromium 截 SVG 元素時，`omitBackground: true` 對**內容自己畫的背景**無效——原圖有一張

--- a/tests/tools/entry-guard.test.ts
+++ b/tests/tools/entry-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// PR #34（外部貢獻）：`import.meta.url === \`file://${process.argv[1]}\`` 在 Windows 上恆為 false，
+// 於是六支 tools 腳本全都印完 banner 就 exit 0，什麼都沒做——包含 `npm run validate` 這道閘門。
+// POSIX 上兩種寫法也不是等價的：`import.meta.url` 會 percent-encode，template literal 不會，
+// 所以只要 checkout 路徑含空白或非 ASCII 字元（例如 ~/我的專案/），Linux 也會踩到同一個空跑。
+// CI 沒抓到是因為 runner 的路徑剛好是純 ASCII。這支測試釘住正確寫法，防止有人複製舊形式回來。
+
+const TOOLS_DIR = join(import.meta.dirname, '../../tools');
+const GUARD = /^if \(import\.meta\.url === .+\) \{$/gm;
+const CORRECT = "if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {";
+
+const scripts = readdirSync(TOOLS_DIR)
+  .filter((f) => f.endsWith('.ts'))
+  .map((f) => [f, readFileSync(join(TOOLS_DIR, f), 'utf8')] as const)
+  .filter(([, src]) => GUARD.test((GUARD.lastIndex = 0, src)));
+
+describe('tools 的 CLI entry guard', () => {
+  it('找得到有 entry guard 的腳本（避免測試因為改名而空跑）', () => {
+    expect(scripts.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(scripts.map(([name]) => name))('%s 用 pathToFileURL 比對，不是 template literal', (name) => {
+    const src = readFileSync(join(TOOLS_DIR, name), 'utf8');
+    expect(src.match(GUARD)).toEqual([CORRECT]);
+    expect(src).toContain("from 'node:url'");
+  });
+});


### PR DESCRIPTION
#34 修掉了 `tools/` 六支腳本的 entry guard，但沒有東西防止舊寫法被複製回來。這支測試補上。

`tests/tools/entry-guard.test.ts` 掃過 `tools/*.ts`，對每支有 entry guard 的腳本斷言：

- guard 一律是 `if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {`
- 檔案有 `import ... from 'node:url'`

外加一條「至少要找到 6 支有 guard 的腳本」，避免有人改了 guard 的形狀之後，
測試因為掃不到任何目標而空跑成綠的。

反例驗過：把 `tools/validate.ts` 的 guard 改回 `` `file://${process.argv[1]}` `` 之後
`1 failed | 6 passed`，還原後 `7 passed`。

`CLAUDE.md` 的「踩過的坑」也記了一節：為什麼舊寫法在 Windows 恆為 false、
為什麼 POSIX 也不安全（`import.meta.url` 會 percent-encode，template literal 不會）、
`?? ''` 的理由，以及這個測試在哪。
