### PR TITLE
perf: 縮小不畫投影、桌機標籤升層、快取畫布量測

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,12 @@ npm run e2e         # 有 pree2e 自動跑 build
   （骰子 50×53 ×41、符文 26×26 ×123、被動小 34×34 ×45、被動大 44×44 ×25、支援 51×47 ×5）。
   **不要再加「類型 → 尺寸」對照表**：同一種類型底下也會有不同尺寸（被動有大小兩種），
   舊的 `sizeOfType()` 就是為此拿掉的。這幾個數字改動後一定要回頭看
-  `src/scripts/tree-canvas.ts` 的兩個 `*_ICON_TARGET_PX`——它們是照骰子寬度換算的，
-  曾經因為骰子從 56 縮到 50 卻沒跟著改，讓每個視角都多放大 12%
+  `src/lib/viewport.ts` 的兩個 `*_ICON_TARGET_PX`——它們是照骰子寬度換算的，
+  曾經因為骰子從 56 縮到 50 卻沒跟著改，讓每個視角都多放大 12%。
+  **同一批還有 `SHADOW_ON_AT_ICON_PX` / `SHADOW_OFF_AT_ICON_PX`**（節點投影的開關門檻，
+  也是量骰子圖示的 CSS 顯示寬度）：`SHADOW_OFF` 必須高於那兩個 `*_ICON_TARGET_PX`，否則
+  「整棵樹都看得到」的預設視角會重新畫滿 239 個 drop-shadow，手機平移直接從 40 掉回 20 FPS。
+  這條不變式在 `tests/lib/viewport.test.ts` 有斷言，改壞了會紅
 - 效能預算硬斷言：`tree.json` gzip ≤ 20KB（**目前 18.9KB，只剩 1.1KB**）、sprite ≤ 400KB（目前 130KB）。
   ⚠️ `tests/tools/build-data.test.ts` 有**兩條**預算斷言：一條量測試自己組的產物（`spriteIndex`
   是 238 筆全同值的替身，全同值壓得比真實座標好，**會低估約 0.5KB**），另一條量 `pretest`

--- a/src/lib/viewport.ts
+++ b/src/lib/viewport.ts
@@ -69,6 +69,28 @@ export const HIRES_UPGRADE_AT = 1.2;
 export const HIRES_DOWNGRADE_AT = 0.9;
 
 /**
+ * 畫節點投影的門檻（單位：**CSS 像素**，量的是骰子圖示的顯示寬度），配一組遲滯。
+ *
+ * ⚠️ 刻意**不**沿用上面高解析圖示那組門檻，兩者問的不是同一個問題：
+ *
+ * - 高解析圖示問「來源解析度夠不夠」→ 判準是**裝置**像素（`effectiveDevicePx`，含 dpr）。
+ * - 投影問「使用者看不看得見」→ 判準是 **CSS** 像素。dpr 只影響銳利度，不影響一個東西
+ *   在眼睛裡多大；`0 1px 1.5px` 是使用者座標單位，換算成 CSS px 才是實際看到的尺寸。
+ *
+ * 共用同一組門檻會在高 dpr 手機上判斷錯：dpr 3.25 的手機在 1.87 倍就越過 devicePx 1.2、
+ * 開始畫投影，但那時畫面上還有約 120 個節點——比同倍率的 dpr1 桌機更糟，而手機正是最慢的
+ * 那台。改用 CSS 像素之後這個不對稱就消失了。
+ *
+ * 數值取自 `applyReadabilityFloor()` 保證的下限：預設視角一定落在
+ * `DESKTOP_ICON_TARGET_PX`（26）／`MOBILE_ICON_TARGET_PX`（35）上。關閉門檻必須**高於
+ * 兩者**，才能保證「整棵樹都看得到」的預設視角一律不畫投影——那正是節點最多、最慢的狀態。
+ * 開啟門檻 50 CSS px 大約是投影（1 單位位移、1.5 單位模糊）開始真的看得出來的尺寸，
+ * 那時畫面上通常只剩幾十個節點。這組不變式有單元測試釘住。
+ */
+export const SHADOW_ON_AT_ICON_PX = 50;
+export const SHADOW_OFF_AT_ICON_PX = 40;
+
+/**
  * 算出「一個使用者座標單位目前攤到幾個裝置像素」。
  *
  * ⚠️ 這是 2026-08-19 review 報告 C05 的核心：舊版的判斷是 `if (vp.scale <= 1) return;`，
@@ -129,6 +151,19 @@ export class Viewport {
   private x = 0;
   private y = 0;
   private s = 1;
+
+  /**
+   * 快取起來的「螢幕座標 → 使用者座標」換算分量，`invalidateCtm()` 會清掉。
+   *
+   * ⚠️ `svg.getScreenCTM()` 是**強制同步版面計算**。2026-08-21 在真實 Chromium 上實測：
+   * 連續 300 次「寫 style.transform 再讀 getScreenCTM」要 40ms，先讀一次存起來只要 0.8ms
+   * （50 倍）。而拖曳時每一個 pointermove 都會走 `pan()`——等於每個輸入事件都白白 flush
+   * 一次版面，那是「拖起來不跟手」的直接來源。
+   *
+   * 快取是安全的，因為這裡讀的是**根 svg** 的 CTM：它只描述畫布元素本身在頁面上的位置與
+   * 大小，跟 `#viewport` 這層 transform 完全無關，拖曳／縮放全程都不會變。
+   */
+  private ctm: { kx: number; ky: number; ex: number; ey: number } | null = null;
 
   constructor(
     private svg: SVGSVGElement,
@@ -202,12 +237,31 @@ export class Viewport {
    * 位移退化為 0，讓既有以「使用者座標＝螢幕座標」為前提寫的測試不必更動。
    */
   private screenToUserCtm(): { kx: number; ky: number; ex: number; ey: number } {
+    if (this.ctm) return this.ctm;
     const ctm = this.svg.getScreenCTM?.();
     const kx = ctm && ctm.a !== 0 ? ctm.a : 1;
     const ky = ctm && ctm.d !== 0 ? ctm.d : 1;
     const ex = ctm?.e ?? 0;
     const ey = ctm?.f ?? 0;
-    return { kx, ky, ex, ey };
+    // 量不到（沒有版面引擎的測試環境、或畫布還沒排版）時退化的 1:1／位移 0 **不進快取**：
+    // 那是暫時狀態，存起來會讓之後真的量得到時仍沿用錯的比例，而且沒有任何事件會通知我們
+    // 「現在量得到了」。每次重問的成本只發生在這個本來就不正常的狀態下。
+    if (!ctm) return { kx, ky, ex, ey };
+    this.ctm = { kx, ky, ex, ey };
+    return this.ctm;
+  }
+
+  /**
+   * 丟掉 CTM 快取，下一次 `pan()`／`zoomAt()` 會重新問一次 `getScreenCTM()`。
+   *
+   * 呼叫端（src/scripts/tree-canvas.ts）負責在「畫布元素在頁面上的位置或大小真的可能變了」
+   * 的時候呼叫：ResizeObserver（涵蓋任何原因造成的尺寸變化，不只視窗縮放）、`resize`、
+   * 捕獲階段的 `scroll`（位移變了但尺寸沒變，ResizeObserver 收不到），以及每一次
+   * `pointerdown`——後者是廉價的保險，讓每個手勢至少重新量一次，代價是整個手勢一次強制
+   * 版面計算，而不是每個 pointermove 一次。
+   */
+  invalidateCtm(): void {
+    this.ctm = null;
   }
 
   /** 依螢幕座標位移（CSS px）平移畫布，內部換算成使用者座標後累加。 */

--- a/src/pages/tree.astro
+++ b/src/pages/tree.astro
@@ -184,6 +184,39 @@ const TYPES: Array<[string, string]> = [
     will-change: transform;
   }
 
+  /*
+   * 標籤升成合成層——**只在有滑鼠的裝置**。2026-08-21 真機 A/B 實測定案。
+   *
+   * 關掉投影之後，畫布剩下的光柵化成本有八成壓在標籤上：畫面上實際渲染的 47 個 `<text>`
+   * （骰子 41＋支援 5＋樹心 1，其餘符文／被動的標籤是 display:none，見下方「標籤擁擠」
+   * 那段），每個約 0.25ms，而 239 個 pattern 填充的節點＋248 條邊加起來才 2.9ms。實測換成
+   * 等長英數一樣慢，所以不是 CJK 的問題，是 SVG `<text>` 在 transform 變動時每一幀都要
+   * 重新光柵化。升成合成層之後平移就退化成 GPU 位移，不再重畫。
+   *
+   *                     164Hz 桌機（有滑鼠）      60Hz 手機 dpr3.25
+   *   不升層             平移掉 62 幀／縮放 41     平移掉 18 幀／縮放 40
+   *   標籤升層           平移掉  0 幀／縮放 83     平移掉  0 幀／縮放 20 ←
+   *
+   * ⚠️ **手機一律不套，而且不是只為了那個縮放數字。** Android Chrome 上只要標籤升成合成層，
+   *   骰子樹就會在平移／縮放時**閃爍**——常駐會閃，改成只在手勢期間加上、手勢結束拿掉
+   *   （試過那一版）也會閃，因為 47 個標籤要從 `#viewport` 那張合成層切出去再併回來，
+   *   兩端各得重畫一次整棵樹。桌機兩種寫法都不閃。既然常駐與否在手機上都不行、而在桌機上
+   *   常駐又比隨手勢進出更快（縮放 83 vs 41，因為縮放期間圖層還在），結論就是這條：
+   *   有滑鼠就常駐，沒滑鼠就完全不碰。
+   *
+   * 判準用 `(hover: hover) and (pointer: fine)` 而不是畫面寬度：會閃的是行動裝置的合成器，
+   * 跟視窗多寬無關——桌機視窗拉窄不該失去這個優化，而寬螢幕的 Android 平板該被排除。
+   *
+   * 另外評估過、都否決掉的：手勢期間隱藏標籤（縮放時字消失太突兀，E2E 的 Z9 有擋）、
+   * 把邊線也升層（手機縮放掉到 10 FPS）、把邊線與標籤烘成點陣圖（邊線只佔 11%，
+   * 烘標籤則要處理篩選淡出、前置鏈高亮、放大變糊與重烘時機，代價遠大於這條 CSS）。
+   */
+  @media (hover: hover) and (pointer: fine) {
+    #viewport text {
+      will-change: transform;
+    }
+  }
+
   /* #tree-controls：#toolbar 與 #branch-nav 共用的 fixed 定位容器，用 flex column
      直向排列，讓 #branch-nav 自然接在 #toolbar「實際渲染高度」之後——不管 #toolbar
      的 flex-wrap 在窄視窗換成幾行，#branch-nav 都不會被蓋到（修 bug：舊版兩者各自
@@ -325,7 +358,23 @@ const TYPES: Array<[string, string]> = [
      縮放一起變化，不會放大後糊成一塊貼圖。數值換算自原圖的
      `feDropShadow dx=0 dy=2 stdDeviation=2.2 flood-opacity=.48`（那組值在 scale(0.72)
      的座標系裡，再乘上站台的 0.5 倍座標）。 */
-  .node .icon {
+  /* ⚠️ 只在 `#tree.shadows` 下才畫，那個 class 由 tree-canvas.ts 的 `updateShadows()`
+     依**骰子圖示目前的 CSS 顯示寬度**切換，門檻與遲滯是 `SHADOW_ON_AT_ICON_PX` /
+     `SHADOW_OFF_AT_ICON_PX`（見 src/lib/viewport.ts，那裡也寫了為什麼刻意**不**沿用
+     高解析圖示那組裝置像素門檻——兩者問的不是同一個問題）。
+
+     這是效能修正，不是外觀取捨。239 個 drop-shadow 各自是一次離屏 filter pass，
+     2026-08-21 用單檔 A/B 測試頁在真機上實測（同一份 DOM、同一組合成層設定，只切這條
+     規則）：
+
+       Android Chrome 手機 60Hz　平移 20→40 FPS、縮放 15→40 FPS
+       164Hz Windows 桌機　　　 平移 82→164 FPS、縮放 28→83 FPS
+
+     縮小時關掉看不出來，因為 `0 1px 1.5px` 是**使用者單位**：全貌視角下每單位不到 0.6
+     個裝置像素，投影換算後只有約 0.5px，本來就低於一個像素。同日的像素比對（隱藏文字
+     以排除反鋸齒雜訊）顯示差異只落在節點邊緣一圈、最大色差 40/255。等縮放大到投影真的
+     看得見時，畫面上也只剩十幾顆節點，239 個 filter 的成本自然不存在。 */
+  #tree.shadows .node .icon {
     filter: drop-shadow(0 1px 1.5px rgb(10 7 18 / 48%));
   }
 
@@ -399,14 +448,27 @@ const TYPES: Array<[string, string]> = [
      圓形節點得到圓環、圓角方塊得到圓角框。CSS 的 outline 做不到——它畫的永遠是矩形邊界框。
      投影要一起寫進來：filter 是單一屬性，只寫 url(#focus-ring) 會把 .node .icon 那條
      投影整條蓋掉，focus 的瞬間節點會突然變扁。 */
+  /* ⚠️ 投影拆成兩條規則，順序與權重都不能動：`#tree.shadows .node .icon` 的權重是
+     (1,3,0)，比 `.node:focus .icon` 的 (0,3,0) 高——只寫一條 focus 規則的話，
+     shadows 模式下被 focus 的節點會被上面那條蓋掉，變成「只有投影、沒有金邊」。
+     下面這條 `#tree.shadows .node:focus .icon` 是 (1,4,0)，權重最高，兩個模式都對。
+     focus 外框是無障礙功能，**任何縮放下都必須在**，不跟著 `.shadows` 開關（同時最多只有
+     一個節點被 focus，那一個 filter 沒有效能問題）。E2E 的 Z8 兩個模式各驗一次。 */
   .node:focus .icon {
+    filter: url(#focus-ring);
+  }
+  #tree.shadows .node:focus .icon {
     filter: url(#focus-ring) drop-shadow(0 1px 1.5px rgb(10 7 18 / 48%));
   }
 
   /* Windows 高對比模式會把 filter 產生的顏色整個抽掉，focus 指示就消失了。那個模式下改用
      老派的矩形 outline——不夠貼合，但「看得見焦點在哪」優先於「框得好不好看」。 */
   @media (forced-colors: active) {
-    .node:focus .icon {
+    /* 兩個選擇器都要列：只寫 `.node:focus .icon` (0,3,0) 的話，shadows 模式下會被上面
+       的 `#tree.shadows .node:focus .icon` (1,4,0) 用權重蓋過去，高對比模式就失效了。
+       列出的第二條權重跟它相同，靠「後出現者勝」拿下（這個區塊在原始碼裡排在後面）。 */
+    .node:focus .icon,
+    #tree.shadows .node:focus .icon {
       filter: none;
       outline: 2px solid;
       outline-offset: 0;

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -11,6 +11,8 @@ import {
   effectiveDevicePx,
   HIRES_UPGRADE_AT,
   HIRES_DOWNGRADE_AT,
+  SHADOW_ON_AT_ICON_PX,
+  SHADOW_OFF_AT_ICON_PX,
 } from '../lib/viewport.js';
 import { computeSelection } from '../lib/selection.js';
 import { renderDetail, nodeViewHtml, termViewHtml, awakeningViewHtml } from '../components/NodeDetail.js';
@@ -83,7 +85,18 @@ window.addEventListener('resize', () => {
   // （dpr 1→2）、手機轉向、進入全螢幕、把視窗拖到高 DPI 螢幕，全都只發 resize。不在這裡
   // 重算的話，使用者會一直停在糊掉的 sprite（或反過來，停在已經沒必要的高解析圖），
   // 直到剛好在畫布上滾一次滾輪為止。
+  // ⚠️ 順序不能換：這兩個判斷的輸入都是畫布盒子，必須先讓快取失效才問得到新尺寸。
+  // 這個 handler 在本檔最前面就註冊了，比下面 invalidateCanvasMetrics() 自己那道
+  // resize 失效更早執行，所以不能指望它——要在這裡自己先叫一次（函式宣告會提升，
+  // 而這個 handler 只在模組執行完之後才會被呼叫，不會有 TDZ 問題）。
+  invalidateCanvasMetrics();
   maybeUpgradeIcons();
+  // 投影門檻同理，而且它連 rAF 都沒有：`updateShadows()` 平常掛在監看 #viewport style 的
+  // MutationObserver 上，但 resize **不會**寫那個 style（Viewport.apply() 只從 pan／
+  // zoomAt／fitTo 進來），那條路接不到。少了這一行，視窗縮小後會停在「圖示已經小到看不見
+  // 投影、卻還在畫 239 個 drop-shadow」的狀態，要等使用者下次滾輪或拖曳才自癒。E2E 的 Z8
+  // 有一段專門釘住這件事。
+  updateShadows();
 });
 
 const host = document.getElementById('canvas-host');
@@ -154,6 +167,76 @@ const DICE_ICON_WIDTH_UNITS = data.nodes.find(n => n.type === 'dice')?.size[0] ?
 // 目標圖示尺寸（兩個常數與它們的由來見 src/lib/viewport.ts）。
 
 /**
+ * 畫布元素盒子的快取，連同 `Viewport` 內部的 CTM 快取一起失效。
+ *
+ * `getBoundingClientRect()` 與 `getScreenCTM()` 都是**強制同步版面計算**，而兩者量的都是
+ * 「畫布元素本身在頁面上的位置與大小」——跟 `#viewport` 那層 transform 無關，拖曳與縮放
+ * 全程都不會變。不快取的話，每一個 pointermove（`pan()` → `screenToUserCtm()`）與每一幀的
+ * `updateShadows()` 都各 flush 一次版面。
+ *
+ * 失效時機刻意用四道，各補一個對方收不到的洞：
+ * - `ResizeObserver`：涵蓋**任何原因**造成的尺寸變化，不只視窗縮放（例如手機網址列收合、
+ *   容器版面改變）。存在性檢查照本檔慣例——測試環境（linkedom）沒有這個 API。
+ * - `resize`：ResizeObserver 不存在時的退路。註冊在本檔最前面那個 resize handler 裡
+ *   （而不是這裡），因為它必須排在同一個 handler 的 maybeUpgradeIcons()／updateShadows()
+ *   之前執行。
+ * - 捕獲階段的 `scroll`：位置變了但尺寸沒變，ResizeObserver 收不到。用捕獲階段才接得到
+ *   內層容器的捲動（scroll 不冒泡）。
+ * - 每次 `pointerdown`：廉價的保險。代價是**整個手勢**一次強制版面計算，而不是每個
+ *   pointermove 一次——那正是這個快取要省掉的東西。
+ */
+let canvasBox: DOMRect | null = null;
+/** 見下方 `updateShadows()`。宣告放在這裡是因為 `invalidateCanvasMetrics()` 要清掉它。 */
+let lastShadowScale = NaN;
+function canvasRect(): DOMRect {
+  if (!canvasBox) canvasBox = svg.getBoundingClientRect();
+  return canvasBox;
+}
+function invalidateCanvasMetrics(): void {
+  canvasBox = null;
+  lastShadowScale = NaN;
+  vp.invalidateCtm();
+}
+if (typeof ResizeObserver === 'function') new ResizeObserver(invalidateCanvasMetrics).observe(svg);
+if (typeof addEventListener === 'function') {
+  // `resize` 不在這裡註冊：本檔最前面那個 resize handler 已經自己叫了
+  // invalidateCanvasMetrics()，而且必須排在它的 maybeUpgradeIcons()／updateShadows()
+  // 之前——在這裡再註冊一次只會是第二個、更晚執行的監聽器，解決不了順序問題，還讓
+  // 「誰負責 resize」有兩個答案。
+  addEventListener('scroll', invalidateCanvasMetrics, { capture: true, passive: true });
+}
+svg.addEventListener('pointerdown', invalidateCanvasMetrics);
+
+/**
+ * 切換 `#tree.shadows`：圖示在畫面上夠大時才畫節點投影（見 src/pages/tree.astro 那條規則的
+ * 說明——239 個 drop-shadow 是縮小視角下光柵化成本的主要來源，實測手機平移 20→40 FPS）。
+ *
+ * 判準是**骰子圖示目前的 CSS 顯示寬度**，門檻與遲滯見 `SHADOW_ON_AT_ICON_PX` /
+ * `SHADOW_OFF_AT_ICON_PX`（src/lib/viewport.ts，那裡也寫了為什麼不沿用高解析圖示那組
+ * 裝置像素門檻）。算式跟 `currentDevicePx()` 同一條，只是 dpr 固定給 1——「攤到幾個 CSS
+ * 像素」就是「攤到幾個裝置像素」把 dpr 拿掉。
+ *
+ * ⚠️ 這個函式**不能**只掛在 `wheel`／`pointerup` 上（`maybeUpgradeIcons()` 就是那樣掛的）。
+ * 雙指縮放要放開手指才會觸發 pointerup，那正好是最慢的一段手勢：整個縮放過程會拖著全部
+ * 投影跑完，放開才切換。所以改掛在監看 `#viewport` style 的 MutationObserver 上（見下方
+ * 詳情卡片那段的說明，`Viewport.apply()` 是所有變動的唯一出口），每一次 transform 變動都
+ * 跟著更新。成本是安全的：盒子已經快取，這裡只剩幾個乘法，而且 scale 沒變時直接短路。
+ */
+function updateShadows(): void {
+  if (vp.scale === lastShadowScale) return;
+  const box = canvasRect();
+  const iconCssPx =
+    effectiveDevicePx(box.width, box.height, data.meta.viewBox[2], data.meta.viewBox[3], vp.scale, 1) *
+    DICE_ICON_WIDTH_UNITS;
+  // 0 代表**量不到**（畫布還沒排版、容器尺寸為 0），不是「小到不必畫投影」。這種狀態下不記
+  // lastShadowScale，才能在盒子量得到之後用同一個 scale 再算一次。
+  if (iconCssPx <= 0) return;
+  lastShadowScale = vp.scale;
+  if (iconCssPx < SHADOW_OFF_AT_ICON_PX) svg.classList.remove('shadows');
+  else if (iconCssPx > SHADOW_ON_AT_ICON_PX) svg.classList.add('shadows');
+}
+
+/**
  * `fitTo(bounds)` 之後，如果算出來的縮放比 `minReadableScale()`（見 src/lib/viewport.ts）
  * 算出的可讀性下限還小，就再疊一次縮放拉到下限；若 `fitTo` 本身給的倍率已經 ≥ 下限，就不去
  * 動它，不會把已經夠清楚的畫面反而縮小。
@@ -175,7 +258,12 @@ const DICE_ICON_WIDTH_UNITS = data.nodes.find(n => n.type === 'dice')?.size[0] ?
  */
 function applyReadabilityFloor(): void {
   const targetPx = isMobile ? MOBILE_ICON_TARGET_PX : DESKTOP_ICON_TARGET_PX;
-  const rect = svg.getBoundingClientRect();
+  // 這裡刻意**先失效再讀**，不吃既有快取。這個函式只在初始視角與分支跳轉時跑（一次工作
+  // 階段幾次，不是每一幀），重新量一次的成本可以忽略；而它正好是「版面剛剛可能變了」的
+  // 時機（首屏排版完成、使用者切換分支）。順手讓這次的新鮮結果進快取，之後的每幀路徑
+  // （updateShadows／maybeUpgradeIcons／pan）就都用得到同一份正確值。
+  invalidateCanvasMetrics();
+  const rect = canvasRect();
   const floor = minReadableScale(
     rect.width,
     rect.height,
@@ -318,7 +406,7 @@ const iconIndex = buildIconIndex(svg);
  * 都會跑的縮放路徑上讀兩次沒有意義。
  */
 function currentDevicePx(): { devicePx: number; box: DOMRect } {
-  const box = svg.getBoundingClientRect();
+  const box = canvasRect();
   const dpr = typeof devicePixelRatio === 'number' && devicePixelRatio > 0 ? devicePixelRatio : 1;
   return {
     devicePx: effectiveDevicePx(box.width, box.height, data.meta.viewBox[2], data.meta.viewBox[3], vp.scale, dpr),
@@ -402,6 +490,12 @@ svg.addEventListener('pointerup', maybeUpgradeIcons);
 // ⚠️ 門檻修正之後，1280×720 dpr1 的桌機首屏**不會**再升級（實測每單位只有 0.52 裝置像素，
 // sprite 綽綽有餘）——這正是修正的重點，不是退步。高 DPI 螢幕與手機才會在這裡真的升級。
 whenIdle(maybeUpgradeIcons);
+
+// 首屏的投影狀態要另外補一次：上面的 MutationObserver 是在本檔更後面才註冊的，而
+// 初始視角（fitTo + applyReadabilityFloor）早在那之前就把 transform 寫進去了——那一次寫入
+// 沒有任何觀察者接得到。少了這一行，桌機首屏會停在「該有投影卻沒有」的狀態，要等使用者
+// 第一次滾輪或拖曳才補上。跟高解析圖示不同，這個不必等 idle：它只是幾個乘法加一個 class。
+updateShadows();
 
 // --- 鍵盤：方向鍵平移、+/- 縮放 ---
 // 這個 handler 掛在 window 上、原本不判斷 focus（「不管焦點在哪都該生效」）；但下面
@@ -637,7 +731,12 @@ if (typeof MutationObserver === 'function') {
   // 包一層而不是直接把 schedulePositionPanel 當 callback：它現在收一個 options 物件，
   // 而 MutationObserver 傳進來的第一個參數是 MutationRecord[]——會被當成 `{keepTop: undefined}`
   // 之外的東西，型別也對不上。畫布一動就是「重新對齊」，不帶 keepTop。
-  new MutationObserver(() => schedulePositionPanel()).observe(viewport, {
+  new MutationObserver(() => {
+    // updateShadows() 也掛在這裡，理由跟卡片一樣：Viewport 的每一次變動最後都落在這個
+    // style 屬性上，一個掛勾全包，不必在每個 zoomAt()／fitTo() 呼叫點後面各補一次。
+    updateShadows();
+    schedulePositionPanel();
+  }).observe(viewport, {
     attributes: true,
     attributeFilter: ['style'],
   });

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -1298,3 +1298,101 @@ test('Z7. 畫布用 CSS transform ＋ will-change 升成合成層（效能修正
   expect(state.hasTransformAttr).toBe(false);
   expect(state.cssTransform).toMatch(/^translate\(-?[\d.]+px, ?-?[\d.]+px\) scale\([\d.]+\)$/);
 });
+
+test('Z8. 縮小時不畫節點投影（239 個 drop-shadow 是光柵化主成本），放大才畫；focus 外框不受影響', async ({ page }) => {
+  await page.goto('/tree');
+  await page.waitForFunction(() => document.querySelectorAll('.node').length >= 239);
+
+  // 滾輪縮放：站台的 wheel handler 一次 1.1 倍，Viewport 把縮放夾在 0.2～8。要跨過
+  // 0.2 → 8 需要 log(40)/log(1.1) ≈ 39 次，這裡給 50 次確保兩個方向都頂到夾制上限，
+  // 也就一定越過高解析門檻（HIRES_UPGRADE_AT / HIRES_DOWNGRADE_AT）。
+  //
+  // 回傳實際到達的縮放倍率讓呼叫端斷言：`page.mouse.wheel()` 有可能被合併或吃掉，
+  // 若不檢查，「滾不夠所以沒切換」會被誤讀成「功能沒生效」——這正是本測試第一版踩到的坑。
+  async function wheelTo(direction: 'in' | 'out'): Promise<number> {
+    const box = (await page.locator('#tree').boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    for (let i = 0; i < 50; i++) await page.mouse.wheel(0, direction === 'in' ? -120 : 120);
+    // maybeUpgradeIcons()／detail class 都排在 rAF／MutationObserver 上，等一幀落地。
+    await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => r(null)))));
+    return page.evaluate(() =>
+      new DOMMatrixReadOnly(getComputedStyle(document.getElementById('viewport')!).transform).a);
+  }
+
+  const read = () => page.evaluate(() => {
+    const svg = document.getElementById('tree')!;
+    const icon = document.querySelector('g.node .icon')!;
+    return { shadows: svg.classList.contains('shadows'), filter: getComputedStyle(icon).filter };
+  });
+
+  expect(await wheelTo('out')).toBeCloseTo(0.2, 3); // 頂到縮放下限
+  const zoomedOut = await read();
+  expect(zoomedOut.shadows).toBe(false);
+  expect(zoomedOut.filter).toBe('none');
+
+  expect(await wheelTo('in')).toBeCloseTo(8, 3); // 頂到縮放上限
+  const zoomedIn = await read();
+  expect(zoomedIn.shadows).toBe(true);
+  expect(zoomedIn.filter).toContain('drop-shadow');
+
+  // focus 外框是無障礙功能，任何縮放下都必須在——這正是最容易被上面那組
+  // `#tree.shadows ...` 選擇器用權重蓋掉的東西（`#tree.shadows .node .icon` 的權重
+  // 高於 `.node:focus .icon`），所以兩種模式各驗一次。
+  const focusFilter = () => page.evaluate(() => {
+    const g = document.querySelector<SVGGElement>('g.node')!;
+    g.focus();
+    return getComputedStyle(g.querySelector('.icon')!).filter;
+  });
+
+  expect(await focusFilter()).toContain('focus-ring');   // 放大狀態
+  await wheelTo('out');
+  expect(await focusFilter()).toContain('focus-ring');   // 縮小狀態
+
+  // 視窗變小也要重算：iconCssPx 的輸入之一是畫布盒子的尺寸，視窗一縮，同一個 vp.scale 下
+  // 圖示的 CSS 顯示寬度就掉一個級距。`resize` 不會寫 #viewport 的 style，所以掛在
+  // MutationObserver 上的那條路接不到——少了 resize 這個呼叫點，畫面會停在「已經小到看不見
+  // 投影、卻還在畫 239 個 drop-shadow」的狀態，正是這個修正要消除的那一個，而且要等使用者
+  // 下次滾輪或拖曳才自癒。瀏覽器縮放（dpr 變動）、手機轉向、進入全螢幕走的都是這條。
+  expect(await wheelTo('in')).toBeCloseTo(8, 3);
+  expect((await read()).shadows).toBe(true);
+  await page.setViewportSize({ width: 400, height: 300 });
+  await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => r(null)))));
+  expect((await read()).shadows).toBe(false);
+});
+
+test('Z9. 標籤只在有滑鼠的裝置升成合成層（手機會閃爍），兩邊標籤都始終看得見', async ({ page, isMobile }) => {
+  await page.goto('/tree');
+  await page.waitForFunction(() => document.querySelectorAll('.node').length >= 239);
+
+  // 要挑真的畫出來的那個標籤：符文／被動的 .label 是 display:none（見 tree.astro 的
+  // 「標籤擁擠」那段），只有骰子 41＋支援 5＋樹心 1 共 47 個會渲染。
+  const read = () => page.evaluate(() => {
+    const label = [...document.querySelectorAll('#viewport text')]
+      .find(t => getComputedStyle(t).display !== 'none')!;
+    const cs = getComputedStyle(label);
+    return {
+      willChange: cs.willChange,
+      visibility: cs.visibility,
+      hasMouse: matchMedia('(hover: hover) and (pointer: fine)').matches,
+    };
+  });
+
+  const before = await read();
+  // 前提斷言：兩個 project 真的被媒體查詢分得開。少了這條，下面那條會在兩邊都變成
+  // 同義反覆（永遠成立），這個測試就再也抓不到「規則寫錯、兩邊都套用」這種回歸。
+  expect(before.hasMouse).toBe(!isMobile);
+  expect(before.willChange).toBe(isMobile ? 'auto' : 'transform');
+
+  // 標籤在任何時候都要看得見：手勢期間隱藏標籤那版被否決了（縮放時字消失太突兀），
+  // 這條擋住它被重新引進。
+  expect(before.visibility).toBe('visible');
+  const box = (await page.locator('#tree').boundingBox())!;
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + 60, box.y + box.height / 2 + 40, { steps: 5 });
+  expect((await read()).visibility).toBe('visible');
+  await page.mouse.up();
+
+  await page.mouse.wheel(0, -120);
+  expect((await read()).visibility).toBe('visible');
+});

--- a/tests/lib/viewport.test.ts
+++ b/tests/lib/viewport.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { parseHTML } from 'linkedom';
-import { Viewport, minReadableScale, effectiveDevicePx, HIRES_UPGRADE_AT, HIRES_DOWNGRADE_AT } from '../../src/lib/viewport';
+import {
+  Viewport,
+  minReadableScale,
+  effectiveDevicePx,
+  HIRES_UPGRADE_AT,
+  HIRES_DOWNGRADE_AT,
+  SHADOW_ON_AT_ICON_PX,
+  SHADOW_OFF_AT_ICON_PX,
+  DESKTOP_ICON_TARGET_PX,
+  MOBILE_ICON_TARGET_PX,
+} from '../../src/lib/viewport';
 
 /** Viewport 沒有公開 layer，測試要斷言 DOM 就靠這張表反查建立時傳進去的那個 <g>。 */
 const layers = new WeakMap<Viewport, SVGGElement>();
@@ -47,6 +57,25 @@ function makeForFitTo() {
  * 曾經只回傳 a/d、`zoomAt` 沒有先減掉 e/f，而測試當時的假 CTM 剛好都是 e=f=0，
  * 沒能抓到。往後這個檔案裡的假 CTM 一律帶非零 e/f，避免同一類 bug 再犯而測試繞過去。
  */
+/**
+ * 跟 `makeWithCtm()` 一樣掛一個假 CTM，但額外記錄 `getScreenCTM()` 被呼叫了幾次，並允許
+ * 中途換掉回傳值——用來驗「拖曳期間只算一次 CTM」這件事真的成立，而不是靠讀不到值矇混過去。
+ */
+function makeCountingCtm(ctm: { a: number; d: number; e: number; f: number }) {
+  const { document } = parseHTML('<html><body></body></html>');
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as unknown as SVGSVGElement;
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g') as unknown as SVGGElement;
+  svg.appendChild(g);
+  const state = { calls: 0, ctm };
+  Object.assign(svg, {
+    getScreenCTM: () => {
+      state.calls++;
+      return { ...state.ctm, b: 0, c: 0 } as unknown as DOMMatrix;
+    },
+  });
+  return { v: new Viewport(svg, g), state };
+}
+
 function makeWithCtm(ctm: { a: number; d: number; e: number; f: number }) {
   const { document } = parseHTML('<html><body></body></html>');
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as unknown as SVGSVGElement;
@@ -316,5 +345,85 @@ describe('effectiveDevicePx（高解析升級的真正判準）', () => {
 
   it('viewBox 壞掉時回 0，不會變成 NaN 一路傳下去', () => {
     expect(effectiveDevicePx(1280, 595, 0, 1700, 2, 1)).toBe(0);
+  });
+});
+
+/**
+ * `svg.getScreenCTM()` 是**強制同步版面計算**：2026-08-21 在真實 Chromium 上實測，連續
+ * 300 次「寫 style.transform 再讀 getScreenCTM」要 40ms，把 CTM 讀一次快取起來只要 0.8ms
+ * （50 倍）。而它讀的是**根 svg** 的 CTM——只跟畫布元素在頁面上的位置與大小有關，跟
+ * `#viewport` 這層 transform 完全無關，拖曳全程不會變。等於每個 pointermove 都白白 flush
+ * 一次版面。這裡把它快取起來，由呼叫端（tree-canvas.ts）在畫布的盒子真的可能變了的時候
+ * （ResizeObserver／resize／scroll／每次 pointerdown）呼叫 `invalidateCtm()`。
+ */
+describe('Viewport：CTM 快取（拖曳時不要每個事件都強制版面計算）', () => {
+  it('連續 pan 只讀一次 getScreenCTM', () => {
+    const { v, state } = makeCountingCtm({ a: 2, d: 2, e: 30, f: 40 });
+    v.pan(10, 10);
+    v.pan(10, 10);
+    v.pan(10, 10);
+    v.pan(10, 10);
+    expect(state.calls).toBe(1);
+  });
+
+  it('pan 與 zoomAt 共用同一份快取', () => {
+    const { v, state } = makeCountingCtm({ a: 2, d: 2, e: 30, f: 40 });
+    v.pan(10, 10);
+    v.zoomAt(2, 100, 100);
+    v.pan(10, 10);
+    expect(state.calls).toBe(1);
+  });
+
+  it('invalidateCtm() 之後會重新讀，而且用的是新的值', () => {
+    const { v, state } = makeCountingCtm({ a: 2, d: 2, e: 0, f: 0 });
+    v.pan(10, 10); // a=2 → 使用者座標 +5
+    expect(v.transform).toBe('translate(5,5) scale(1)');
+    expect(state.calls).toBe(1);
+
+    // 視窗被拉過：畫布的螢幕縮放變了。沒有失效機制的話，下面這次 pan 會沿用舊的 a=2。
+    state.ctm = { a: 4, d: 4, e: 0, f: 0 };
+    v.invalidateCtm();
+    v.pan(10, 10); // a=4 → 使用者座標 +2.5
+    expect(state.calls).toBe(2);
+    expect(v.transform).toBe('translate(7.5,7.5) scale(1)');
+  });
+
+  it('快取不會讓 zoomAt 的錨點換算失準：失效後錨點吃新的 e/f', () => {
+    const { v, state } = makeCountingCtm({ a: 1, d: 1, e: 100, f: 100 });
+    v.zoomAt(2, 300, 300); // 使用者座標錨點 (200,200)
+    expect(v.transform).toBe('translate(-200,-200) scale(2)');
+
+    // 側欄收合，畫布左上角往左移了 100px。
+    state.ctm = { a: 1, d: 1, e: 0, f: 0 };
+    v.invalidateCtm();
+    // factor 必須 ≠ 1。用 1 的話 `x = ux - (ux - x) * 1 === x`，ux 整個抵消掉，斷言會
+    // 恆真、守不住任何東西（2026-08-21 code review 抓到本測試的第一版正是這樣）。
+    // 這裡用 2：新的 e/f 算出 ux=300 → translate(-700,-700)，沿用舊的 e/f=100 會算出
+    // ux=200 → translate(-600,-600)，兩者分得開。
+    v.zoomAt(2, 300, 300);
+    expect(state.calls).toBe(2);
+    expect(v.transform).toBe('translate(-700,-700) scale(4)');
+  });
+});
+
+describe('投影門檻（SHADOW_*_AT_ICON_PX）的不變式', () => {
+  it('有遲滯：開啟門檻嚴格高於關閉門檻', () => {
+    expect(SHADOW_ON_AT_ICON_PX).toBeGreaterThan(SHADOW_OFF_AT_ICON_PX);
+  });
+
+  /**
+   * 這條是整個效能修正的地基，不是湊數的斷言。
+   *
+   * `applyReadabilityFloor()` 保證預設視角的圖示顯示寬度**至少**是這兩個目標值——也就是
+   * 「整棵樹／整個分支都看得到」那個節點最多、最慢的狀態，一定落在門檻上。關閉門檻只要
+   * 掉到任何一個目標值以下，那個狀態就會重新畫滿 239（或數十）個 drop-shadow，
+   * 2026-08-21 真機實測的手機平移 20→40 FPS 直接還回去。
+   *
+   * 日後有人調 DESKTOP_ICON_TARGET_PX／MOBILE_ICON_TARGET_PX（例如骰子顯示尺寸改了要
+   * 照比例重算）時，這條測試會紅，提醒他一起看投影門檻。
+   */
+  it('關閉門檻高於預設視角保證的圖示尺寸：預設視角一律不畫投影', () => {
+    expect(SHADOW_OFF_AT_ICON_PX).toBeGreaterThan(DESKTOP_ICON_TARGET_PX);
+    expect(SHADOW_OFF_AT_ICON_PX).toBeGreaterThan(MOBILE_ICON_TARGET_PX);
   });
 });


### PR DESCRIPTION
## 問題

畫布在節點多的視角拖曳／縮放會卡。上一次修正（#36，改用 CSS transform ＋ `will-change` 讓畫布升成合成層）解決了「SVG `transform` attribute 不會升成合成層」那一半，但實測顯示還有兩塊更大的成本沒動到。

## 診斷

用單檔 A/B 測試頁在兩台真機上量（同一份 DOM、同一組合成層設定，每次只切一條 CSS 規則）。**這些數字全部來自實機，不是模擬**——軟體光柵器量不到光柵化成本，在這次調查中誤導過兩次。

**第一塊：節點投影。** `.node .icon` 上的 `filter: drop-shadow()` 每一個都是一次離屏 filter pass，239 個節點就是每幀 239 次。

| | 現況 | 關掉投影 |
|---|---|---|
| Android Chrome 60Hz 平移 | 20 FPS | **40 FPS** |
| Android Chrome 60Hz 縮放 | 15 FPS | **40 FPS** |
| 164Hz 桌機 平移 | 82 FPS | **164 FPS** |
| 164Hz 桌機 縮放 | 28 FPS | **83 FPS** |

**第二塊：標籤。** 關掉投影之後，剩下的成本有八成壓在畫面上實際渲染的 47 個 `<text>`（骰子 41＋支援 5＋樹心 1，其餘符文／被動的標籤是 `display:none`），每個約 0.25ms；239 個 pattern 填充的節點加 248 條邊合計才 2.9ms。換成等長英數一樣慢，所以不是 CJK 的問題，是 SVG `<text>` 在 transform 變動時每幀都要重新光柵化。

| | 不升層 | 標籤升成合成層 |
|---|---|---|
| 桌機 平移 | 掉 62 幀 | **掉 0 幀** |
| 桌機 縮放 | 41 FPS | **83 FPS** |
| 手機 平移 | 掉 18 幀 | **掉 0 幀** |
| 手機 縮放 | 40 FPS | **20 FPS** ← 反效果 |

**第三塊：強制版面計算。** `Viewport.pan()` 每一次 pointermove 都呼叫 `svg.getScreenCTM()`，那是強制同步版面計算（實測連續 300 次 40ms，讀一次快取起來只要 0.8ms）。它讀的是根 svg 的 CTM，只跟畫布元素在頁面上的位置大小有關，拖曳全程不會變。

## 改動

**1. 投影只在圖示夠大時才畫**（`#tree.shadows`，判準是骰子圖示目前的 CSS 顯示寬度，50px 開／40px 關，有遲滯）。門檻刻意高於 `applyReadabilityFloor()` 保證的預設視角尺寸（桌機 26px／手機 35px），所以「整棵樹／整個分支都看得到」那個節點最多、最慢的狀態一律不畫投影；這條不變式有單元測試釘住，日後調整圖示目標尺寸會紅。

判準用 **CSS** 像素而不是沿用高解析圖示那組**裝置**像素門檻：兩者問的不是同一件事——高解析圖示問「來源解析度夠不夠」（要含 dpr），投影問「使用者看不看得見」（dpr 只影響銳利度、不影響在眼睛裡多大）。共用會在高 dpr 手機上判斷錯：dpr 3.25 的手機在 1.87 倍就開始畫投影，那時畫面上還有約 120 個節點，比同倍率的 dpr1 桌機更糟，而手機正是最慢的那台。

外觀代價：全貌視角下投影只剩節點邊緣一圈 1px，像素比對（排除文字反鋸齒雜訊後）最大色差 40/255。原因是 `0 1px 1.5px` 是使用者單位，全貌下換算不到 0.6 個裝置像素。

focus 外框拆成獨立規則，**任何縮放下都保留**——`#tree.shadows .node .icon` 的權重高於 `.node:focus .icon`，只寫一條會變成「有投影沒金邊」。高對比模式的覆寫也一併補了權重。

**2. 標籤只在有滑鼠的裝置常駐升成合成層**（`@media (hover: hover) and (pointer: fine)`）。

手機一律不套，不是只為了上表那個縮放數字：Android Chrome 上只要標籤升成合成層，骰子樹就會在平移／縮放時**閃爍**——常駐會閃，改成只在手勢期間加上、結束拿掉也會閃（那一版做出來實測後退掉了），因為 47 個標籤要從 `#viewport` 那張合成層切出去再併回來，兩端各得重畫一次整棵樹。桌機兩種寫法都不閃，而常駐比隨手勢進出更快（縮放 83 vs 41，因為縮放期間圖層還在）。

判準用 `hover`／`pointer` 而不是畫面寬度：會閃的是行動裝置的合成器，跟視窗多寬無關——桌機視窗拉窄不該失去這個優化，寬螢幕的 Android 平板該被排除。

**3. 快取畫布的 `getBoundingClientRect()` 與 `getScreenCTM()`**，由 `ResizeObserver`／`resize`／捕獲階段 `scroll`／每次 `pointerdown` 四道失效，各補一個對方收不到的洞。一次拖曳的強制版面計算從 40 次降到 1 次。`applyReadabilityFloor()` 刻意先失效再讀、不吃快取——它一次工作階段只跑幾次，而且正好是版面剛可能變過的時機。

`will-change: transform` 在 `#viewport` 上維持不動：A/B 測試中拿掉它手機只剩 8～9 FPS。

## 評估過但否決的做法

- **手勢期間隱藏標籤**：上限最好（桌機 161／手機 60 FPS），但縮放時字消失太突兀。E2E 的 Z9 有一條斷言擋住它被重新引進。
- **把邊線也升成合成層**：手機縮放掉到 10 FPS。
- **把邊線與標籤烘成點陣圖**：邊線只佔 11%，烘標籤則要處理篩選淡出、前置鏈高亮、放大變糊與重烘時機，代價遠大於一條 CSS。
- **整層套一個 filter 取代 239 個**：外觀不變但仍要 2/3 的成本，而且會開一張蓋住整棵樹的離屏緩衝。

## 驗證

- `typecheck` 乾淨、單元測試 354 全綠（27 個檔）、E2E 85 全綠（9 skipped）
- 新增 E2E **Z8**：縮小無投影、放大有投影、focus 外框在兩種模式下都在。滾輪滾到夾制上下限並斷言真的到了——否則「滾不夠所以沒切換」會被誤讀成「功能沒生效」（本測試第一版就踩過）。
- 新增 E2E **Z9**：桌機 `will-change: transform`／手機 `auto`，兩邊標籤在靜止、拖曳中、滾輪後都是 `visible`。含前提斷言 `hasMouse === !isMobile`，少了它主斷言會在兩個 project 都退化成同義反覆。
- 新增單元測試：CTM 快取與失效（含「失效後要吃到新的 e/f，錨點換算不能失準」）、投影門檻高於可讀性下限的不變式。
- 正式建置實測：桌機全貌無投影、標籤 `will-change: transform`；手機標籤 `auto`；兩邊 47 個標籤都 `visible`、零 JS 錯誤。一次 40 個 pointermove 的拖曳只觸發 1 次 `getScreenCTM` 與 1 次 `getBoundingClientRect`（改動前各 40 次）。

## 已知未解

手機的改善全部來自第 1 項（平移 20→40、縮放 15→40 FPS），第 2 項在手機上刻意留空。要再往上只剩「手機完全不畫標籤」、「烘成點陣圖」或「改 `<canvas>` 重寫互動層」三條，各自的代價見上面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8XCX1TZoqttoZrg47nHNo
