### PR TITLE
SEO：補上 sitemap、robots.txt、canonical 與 404 頁

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,14 +312,34 @@ endpoint 掛掉時它會**安靜地不出現**，那是刻意的降級。
 這跟版面驗收要用幾何斷言是同一條原則。
 
 順帶：前端判斷 API 成功與否**不看 status code**，只看 payload 形狀
-（`typeof body.n === 'number'`）——因為未知路徑回 200、Functions 沒部署時回 405。
+（`typeof body.n === 'number'`）。理由是「`/api/hits` 沒部署時回什麼」完全取決於 `dist/`
+裡有什麼，而那會變：2026-08-22 補上 404 頁之前是 **200 ＋ 一份首頁 HTML**，之後是 **404**，
+POST 到一個存在的靜態路徑則是 **405**。三種都不是數字，所以判準只能是 payload 形狀
+——**不要因為現在有 404 了就改回去信 status code**。
 
-### ⚠️ 未知路徑目前回 200 加一份首頁，不是 404
+### SEO 基礎欄位：robots.txt／sitemap／canonical／404（2026-08-22 補齊，#24–#26）
 
-`dist/` 裡沒有 `404.html` 時，Cloudflare Pages 會當成 SPA 處理、拿 index.html 當 fallback。
-實測 `curl -sI https://rd2-wiki.pages.dev/this-does-not-exist-12345` → `HTTP/2 200`，
-內容是 `<title>首頁 rd2-wiki</title>`。打錯的網址與失效的分享連結都會被搜尋引擎和連結預覽
-當成有效頁面。要修就是加一個 `public/404.html`（尚未做）。
+在這之前 `dist/` 裡沒有 `404.html`，Cloudflare Pages 會當成 SPA 處理、拿 index.html 當
+fallback：`curl -sI .../this-does-not-exist-12345` 回 **200**、內容是首頁。連帶讓
+`/robots.txt` 與 `/sitemap.xml` 也回 200，**看起來像存在其實不存在**。現在四件事都補上了：
+
+- **`public/robots.txt`**——靜態檔，`Sitemap:` 那行是絕對網址，換網域要跟 `site` 一起改
+- **`@astrojs/sitemap`**——`astro.config.mjs` 的 `integrations`，產出 `sitemap-index.xml`
+  ＋ `sitemap-0.xml`。⚠️ **不要加 `filter` 排除 404**：實測（3.7.3）不帶任何選項產出的
+  `<loc>` 就只有三個現有頁面，404 是套件預設就排除的，自己寫的 filter 是死碼
+- **`src/pages/404.astro`**（⚠️ 不是 issue 原本寫的 `public/404.html`）——產物同樣是
+  `dist/404.html`、Pages 一樣認，但走 Astro 才吃得到 `Base.astro` 的導覽列與樣式；
+  寫成 public/ 底下的靜態 HTML 就得複製一份無人看守、必然漂移的樣式副本
+- **`Base.astro` 的 `<title>` 與 canonical**——標題格式是 **`Random Dice 2 wiki | 分頁名`**
+  （站名在前，2026-08-22 定案），分隔符是半形 `|`；新增 `noIndex` prop，目前只有 404 頁用，
+  開起來會**省略 canonical 並加 `<meta name="robots" content="noindex">`**
+  （404 頁的 canonical 只會固定指向 `/404/`，等於邀請搜尋引擎去索引那個網址）
+
+⚠️ **`tests/e2e/seo.spec.ts` 的 SEO-5「未知路徑回 404」在本機是假綠。**
+E2E 的 webServer 是 `serve dist`，它對找不到的檔案本來就回 404，`dist/404.html` 存不存在
+都一樣——soft 404 是 **Cloudflare Pages 那端**的行為。那條守的是「本機沒退步」，
+真正的驗收只能在部署後對正式站做：
+`curl -o /dev/null -w '%{http_code}\n' https://rd2-wiki.pages.dev/no-such-page` 要回 404。
 
 ### ⚠️ 兩個工作區同時跑 E2E 會互相偷 server
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,18 @@
 // 純靜態產出（output: 'static'）：build:data 先產生 src/generated/tree.json 與
 // public/assets 圖示資產，astro build 再把整站編譯進 dist/。
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
+  // `site` 同時餵三個地方：sitemap 裡的 <loc>、Base.astro 的 canonical 與 og:url。
+  // 換網域（#27）時只改這一行，不要在版面裡再寫死一次。
   site: 'https://rd2-wiki.pages.dev',
   output: 'static',
+  // sitemap 不帶任何選項是刻意的。
+  // ⚠️ 一開始寫了 `filter: page => !page.includes('/404')`，怕 404 頁被收進去——實測
+  // （2026-08-22，@astrojs/sitemap 3.7.3）**拿掉 filter 產出的 <loc> 一樣只有三個**，
+  // 404 是這個套件預設就排除的。那個 filter 是一行永遠為真的死碼，留著會讓下一個人
+  // 以為「排除 404」是我們設定的功勞。`tests/e2e/seo.spec.ts` 的 SEO-2 仍然斷言 sitemap
+  // 不含 404——那條守的是上游哪天改掉這個預設。
+  integrations: [sitemap()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "rd2-wiki",
       "devDependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "@playwright/test": "^1.49.0",
         "@types/node": "^24.0.0",
         "astro": "^5.0.0",
@@ -75,6 +76,28 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1755,6 +1778,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -5927,6 +5960,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
@@ -5972,6 +6025,13 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "e2e": "playwright test"
   },
   "devDependencies": {
+    "@astrojs/sitemap": "^3.7.3",
+    "@playwright/test": "^1.49.0",
     "@types/node": "^24.0.0",
     "astro": "^5.0.0",
     "linkedom": "^0.18.0",
+    "serve": "^14.2.0",
     "sharp": "^0.34.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
-    "vitest": "^2.1.0",
-    "@playwright/test": "^1.49.0",
-    "serve": "^14.2.0"
+    "vitest": "^2.1.0"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+# 全站開放索引。這個站沒有登入區、沒有後台，也沒有會產生無限網址的參數頁，
+# 所以不需要任何 Disallow。
+User-agent: *
+Allow: /
+
+# 絕對網址是規格要求（相對路徑多數爬蟲不吃）。檔名是 @astrojs/sitemap 產出的索引檔，
+# 它再指向 sitemap-0.xml；網域改了要跟 astro.config.mjs 的 site 一起改。
+Sitemap: https://rd2-wiki.pages.dev/sitemap-index.xml

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,9 +8,20 @@ import { FEATURES } from '../lib/flags';
 
 interface Props {
   title: string;
+  /**
+   * 這一頁不要被搜尋引擎收錄（目前只有 404 頁用）。
+   * 開起來會同時做兩件事：省略 canonical、加上 `<meta name="robots" content="noindex">`。
+   */
+  noIndex?: boolean;
 }
 
-const { title } = Astro.props;
+const { title, noIndex = false } = Astro.props;
+
+/**
+ * 分頁標題的站名前綴。格式是「站名 | 分頁名」，站名在前（2026-08-22 定案）。
+ * ⚠️ 不要改成破折號：2026-08-18 明確要求分頁標題不帶破折號，`tests/e2e/tree.spec.ts` 的 R 有守。
+ */
+const SITE_NAME = 'Random Dice 2 wiki';
 
 /** 連結預覽卡片的標題。全站固定，不隨分頁變動——理由見 <head> 裡的說明。 */
 const OG_TITLE = 'Random Dice 2 wiki - Fan made';
@@ -24,7 +35,17 @@ const imageUrl = new URL('/favicon.png', Astro.site).href;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title} rd2-wiki</title>
+    <title>{SITE_NAME} | {title}</title>
+    <!--
+      canonical：告訴搜尋引擎「這一頁的正規網址是哪一個」。同一份內容被多個網址打得到時
+      （帶追蹤參數的連結、有無尾斜線、日後的自訂網域），沒有這一行就會被分成好幾份重複內容，
+      權重也跟著散掉。網址用 astro.config.mjs 的 `site` 組出來的絕對網址，跟 og:url 同一個。
+
+      noIndex 的頁面刻意不輸出 canonical：那種頁面本來就不該被收錄，指一個正規網址給它
+      反而是在說「這個網址值得索引」。
+    -->
+    {!noIndex && <link rel="canonical" href={pageUrl} />}
+    {noIndex && <meta name="robots" content="noindex" />}
     <!-- 分頁圖示用陰陽骰子（節點 4008）的骰子本體，不含節點底板：底板在 32px 下會吃掉四周
          約四分之一的面積，把中間的陰陽符號擠到看不清。圖是方形畫布置中的透明 PNG——favicon
          的顯示位置是正方形，直接放長方形圖會被壓扁。 -->
@@ -36,7 +57,7 @@ const imageUrl = new URL('/favicon.png', Astro.site).href;
 
       標題刻意**全站固定**、不帶頁名：貼出去的是「這個站」，收到連結的人要先認出它是什麼，
       而不是「骰子樹」這種只有站內才有意義的分頁名。沒有這幾行的時候，各平台是拿 <title>
-      湊出來的，顯示成「骰子樹 rd2-wiki」。
+      湊出來的，顯示成「Random Dice 2 wiki | 骰子樹」。
 
       og:url 與 og:image 一定要是絕對網址（規格要求，相對路徑多數平台直接不顯示）——
       靠 astro.config.mjs 的 `site` 組出來，不在這裡再寫死一次網域。
@@ -45,7 +66,11 @@ const imageUrl = new URL('/favicon.png', Astro.site).href;
     <meta property="og:site_name" content={OG_TITLE} />
     <meta property="og:title" content={OG_TITLE} />
     <meta property="og:description" content={DESCRIPTION} />
-    <meta property="og:url" content={pageUrl} />
+    <!-- og:url 吃跟 canonical 同一個判斷。404 頁是 Cloudflare Pages 拿來回**任何**未知
+         路徑的那一份，`pageUrl` 卻固定是 `/404/`——貼一個失效連結到聊天室時，卡片會宣稱
+         自己代表 `/404/`，那既不是使用者貼的網址，也不是這份檔案實際被服務的路徑。
+         省略它，各平台會退回用實際請求的網址。 -->
+    {!noIndex && <meta property="og:url" content={pageUrl} />}
     <meta property="og:image" content={imageUrl} />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={OG_TITLE} />

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -13,6 +13,12 @@ export const FEATURES = {
    *
    * 關掉的是**入口**，不是頁面：`/about` 直接輸入網址仍然打得開，只是不再從導覽列曝光。
    * 要整頁擋掉是另一件事（得動 astro 的路由或加 404），目前沒這個需求。
+   *
+   * ⚠️ **`/about` 仍然在 sitemap 裡**（2026-08-22 起），也就是站內沒有任何連結指向它、
+   * 卻主動提交給搜尋引擎。那是刻意的：它渲染的是 CONTRIBUTING.md，是全站文字量最大的一頁。
+   * 如果哪天這個開關要改成「真的藏起來」，得**三個地方一起改**——這裡、
+   * `astro.config.mjs` 的 sitemap 設定、以及 `tests/e2e/seo.spec.ts` 的 `PAGES`
+   * （SEO-2 用完全相等比對 `<loc>` 清單，少一頁多一頁都會紅）。
    */
   contributeLink: false,
 } as const;

--- a/src/lib/hit-counter.ts
+++ b/src/lib/hit-counter.ts
@@ -56,6 +56,10 @@ function safeSessionStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
  * ⚠️ 成功與否**不能靠 status code 判斷**。實測線上站：dist/ 裡沒有 404.html 時，
  * Cloudflare Pages 把未知路徑當 SPA，GET 未知路徑會回 200 加一份完整的首頁 HTML；
  * 而 functions 沒被部署時 POST 回的是 405 不是 404。唯一可靠的判準是 payload 形狀。
+ *
+ * ⚠️ 2026-08-22 起 `dist/404.html` 存在了，所以上面第一種情形變成回 404——但這反而更說明
+ * 不該信 status code：同一段程式在部署狀態沒變的情況下，看到的碼從 200 變成 404。
+ * 三種可能（200／404／405）都不是數字，`!res.ok` 只是第一道濾網，真正的判準仍是形狀。
  */
 export async function fetchHitNumber(deps: HitCounterDeps = {}): Promise<number | null> {
   const doFetch = deps.fetch ?? globalThis.fetch;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,22 @@
+---
+// 404 頁。
+//
+// ⚠️ 為什麼是 `src/pages/404.astro` 而不是 `public/404.html`：兩者的產物同樣是
+// `dist/404.html`，Cloudflare Pages 一樣會拿它來回未知路徑，但走 Astro 這條路才吃得到
+// Base.astro 的導覽列、頁尾與全站樣式。寫成 public/ 底下的靜態 HTML 就得複製一份樣式，
+// 那份副本沒有任何東西守著，改版面時一定會漂移。
+//
+// 它解掉的是 soft 404：在這個檔案存在之前，未知路徑回的是 HTTP 200 ＋ 首頁內容，
+// 於是無限多個不存在的網址都被判成首頁的重複內容，`/robots.txt` 與 `/sitemap.xml`
+// 也因此「看起來存在」（見 tests/e2e/seo.spec.ts 的說明）。
+import Base from '../layouts/Base.astro';
+---
+
+<Base title="找不到頁面" noIndex>
+  <section style="padding:2rem">
+    <h1>找不到這一頁</h1>
+    <p style="color:var(--muted)">網址可能打錯了，或這一頁已經搬走。</p>
+    <p><a href="/tree">開啟骰子樹 →</a></p>
+    <p><a href="/">回首頁</a></p>
+  </section>
+</Base>

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -1,0 +1,112 @@
+// SEO 基礎欄位的端對端驗證（issues #24／#25／#26）。
+//
+// 為什麼這幾條非得走真實 HTTP 不可：這三項全部壞掉的時候，站台用瀏覽器逛起來完全正常。
+// 2026-08-20 的實測就是這樣被騙的——`/robots.txt` 與 `/sitemap.xml` 都回 HTTP **200**，
+// 看起來像存在，其實回的是首頁的 HTML（未知路徑回退造成的假象）。只有去讀
+// **狀態碼與 content-type** 才會說話，讀 DOM 是讀不出來的。
+//
+// 三個檔案在這裡合成一個 spec，是因為它們互相依賴：robots.txt 指向 sitemap，
+// sitemap 列出的網址要跟 canonical 對得起來，而「未知路徑回什麼」同時決定前兩者
+// 是不是假象。
+import { test, expect } from '@playwright/test';
+
+/** 正式站網址。canonical 與 sitemap 裡的絕對網址都應該長這樣，跟本機測試埠無關。 */
+const SITE = 'https://rd2-wiki.pages.dev';
+
+/**
+ * 全站現有的頁面：請求路徑 → 建置後的正規路徑（含尾斜線）與分頁名。
+ * Astro 產出的是 `dist/tree/index.html`，所以自我指涉的絕對網址帶尾斜線。
+ */
+const PAGES = [
+  { request: '/', canonical: `${SITE}/`, name: '首頁' },
+  { request: '/tree', canonical: `${SITE}/tree/`, name: '骰子樹' },
+  { request: '/about', canonical: `${SITE}/about/`, name: '貢獻' },
+] as const;
+
+test('SEO-1. robots.txt 是真的純文字檔，不是首頁的回退', async ({ request }) => {
+  const res = await request.get('/robots.txt');
+  expect(res.status()).toBe(200);
+  // ⚠️ 這一行是整個 #24 的核心：回退回來的首頁也是 200，靠 content-type 才分得出來。
+  expect(res.headers()['content-type']).toContain('text/plain');
+
+  const body = await res.text();
+  expect(body).not.toContain('<html'); // 再保險一次：內容不能是 HTML
+  expect(body).toContain('User-agent: *');
+  expect(body).toContain(`Sitemap: ${SITE}/sitemap-index.xml`);
+});
+
+test('SEO-2. sitemap 存在、是 XML，且剛好列出三個現有頁面', async ({ request }) => {
+  const index = await request.get('/sitemap-index.xml');
+  expect(index.status()).toBe(200);
+  expect(index.headers()['content-type']).toContain('xml');
+  expect(await index.text()).toContain(`${SITE}/sitemap-0.xml`);
+
+  const res = await request.get('/sitemap-0.xml');
+  expect(res.status()).toBe(200);
+  expect(res.headers()['content-type']).toContain('xml');
+
+  // 捕獲組必然有值（正則本身就要求 <loc> 內至少一個字元），但 tsc 看不出來——
+  // 用 flatMap 過濾比 `!` 斷言誠實：真的抓不到東西時 urls 會是空陣列，下一行的相等比對
+  // 就會紅，而不是拿一堆 undefined 去比。
+  const urls = [...(await res.text()).matchAll(/<loc>([^<]+)<\/loc>/g)].flatMap(m =>
+    m[1] ? [m[1]] : []
+  );
+  // 用相等而不是包含：漏一頁跟多一頁都要說話。
+  expect(urls.sort()).toEqual(PAGES.map(p => p.canonical).sort());
+  // 404 頁是靜態產出的一頁，預設會被 sitemap 收進去——提交一個「保證是 404」的網址給
+  // 搜尋引擎正好是 #26 想解掉的問題的反面，所以要明確排除。
+  expect(urls).not.toContain(`${SITE}/404/`);
+  expect(urls.some(u => u.includes('404'))).toBe(false);
+});
+
+for (const page_ of PAGES) {
+  test(`SEO-3. ${page_.request} 的 canonical 指向自己的絕對網址`, async ({ page }) => {
+    await page.goto(page_.request);
+    const href = await page.locator('link[rel="canonical"]').getAttribute('href');
+    expect(href).toBe(page_.canonical);
+  });
+
+  test(`SEO-4. ${page_.request} 的 <title> 帶站名與分頁名`, async ({ page }) => {
+    await page.goto(page_.request);
+    // 站名在前、分頁名在後（2026-08-22 Yuki 指定的格式），分隔符是半形直立線。
+    expect(await page.title()).toBe(`Random Dice 2 wiki | ${page_.name}`);
+  });
+}
+
+test('SEO-5. 未知路徑回 404 而不是首頁', async ({ page, request }) => {
+  const res = await request.get('/no-such-page-abc123');
+  // soft 404 的樣子就是這裡回 200 ＋ 首頁的 HTML；那會讓無限多個不存在的網址
+  // 全部被判成首頁的重複內容。
+  //
+  // ⚠️ 這一行在本機是**假綠**：E2E 的 webServer 是 `serve dist`，它對找不到的檔案本來就
+  // 回 404，`dist/404.html` 存不存在都一樣。soft 404 是 **Cloudflare Pages** 那端的行為
+  // （2026-08-20 實測正式站回 200 ＋ 首頁）。所以這條守的是「本機沒退步」，
+  // 真正的驗收是部署後對正式站 `curl -o /dev/null -w '%{http_code}'`。
+  expect(res.status()).toBe(404);
+
+  const body = await res.text();
+  expect(body).toContain('找不到這一頁');
+  // 首頁的特徵：訪客計數器只有首頁有。回退到首頁時這裡會命中。
+  expect(body).not.toContain('id="hit-counter"');
+
+  await page.goto('/no-such-page-abc123');
+  expect(await page.title()).toBe('Random Dice 2 wiki | 找不到頁面');
+  // 404 頁要能自己走回去，不然使用者只能按上一頁。
+  await expect(page.locator('main a[href="/tree"]')).toBeVisible();
+});
+
+test('SEO-6. 404 頁不宣稱自己是任何網址', async ({ page }) => {
+  // 這一份 HTML 會被 Cloudflare Pages 拿來回**每一個**未知路徑，所以任何「我的網址是 X」
+  // 的宣告都是錯的：canonical 會邀請搜尋引擎去索引 /404/，og:url 會讓聊天室的預覽卡片
+  // 宣稱一個失效連結代表 /404/。兩者都必須不存在，改由 noindex 明講。
+  await page.goto('/no-such-page-abc123');
+  await expect(page.locator('link[rel="canonical"]')).toHaveCount(0);
+  await expect(page.locator('meta[property="og:url"]')).toHaveCount(0);
+  expect(await page.locator('meta[name="robots"]').getAttribute('content')).toBe('noindex');
+
+  // 反面：正常頁面三者都要在，免得哪天 noIndex 的預設值寫反、整站一起消音。
+  await page.goto('/tree');
+  await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+  await expect(page.locator('meta[property="og:url"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"]')).toHaveCount(0);
+});

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -980,7 +980,7 @@ test('P. 工具列對齊：搜尋框與分支側欄切齊同一條左邊界，�
 test('R. 分頁標題不帶破折號，分頁圖示指向實際存在的檔案', async ({ page }) => {
   await page.goto('/tree');
   const title = await page.title();
-  expect(title).toBe('骰子樹 rd2-wiki');
+  expect(title).toBe('Random Dice 2 wiki | 骰子樹');
   expect(title).not.toContain('—'); // 破折號拿掉了（2026-08-18 要求）
 
   // 圖示只寫在 <head> 是不夠的：路徑打錯時瀏覽器只會安靜地退回預設圖示，沒有任何錯誤。
@@ -993,7 +993,7 @@ test('R. 分頁標題不帶破折號，分頁圖示指向實際存在的檔案',
 });
 
 test('S. 連結預覽卡片：標題全站固定，網址與圖片都是絕對網址且圖片存在', async ({ page }) => {
-  // 貼進聊天室展開的卡片。沒有這些標籤時各平台是拿 <title> 湊，顯示成「骰子樹 rd2-wiki」。
+  // 貼進聊天室展開的卡片。沒有這些標籤時各平台是拿 <title> 湊，顯示成「Random Dice 2 wiki | 骰子樹」。
   await page.goto('/tree');
   const meta = (sel: string) => page.locator(sel).getAttribute('content');
   expect(await meta('meta[property="og:title"]')).toBe('Random Dice 2 wiki - Fan made');


### PR DESCRIPTION
一次解掉 #24、#25、#26。三件事互相依賴——robots.txt 指向 sitemap、sitemap 的網址要跟 canonical 對得起來，而「未知路徑回什麼」決定前兩者是不是假象——所以合成一個 PR。

## 改了什麼

- **`@astrojs/sitemap`**：產出 `sitemap-index.xml` ＋ `sitemap-0.xml`，列出 `/`、`/tree/`、`/about/` 三頁。**不帶 `filter`**：原本寫了一行 `filter` 排除 404 頁，實測拿掉之後 `<loc>` 一樣只有三個——404 是這個套件預設就排除的（`STATUS_CODE_PAGES`），那行是死碼。
- **`public/robots.txt`**：`Sitemap:` 用絕對網址。
- **`src/pages/404.astro`**（不是 issue 原本寫的 `public/404.html`）：產物同樣是 `dist/404.html`、Cloudflare Pages 一樣認，但走 Astro 才吃得到 `Base.astro` 的導覽列與樣式；寫成 public/ 底下的靜態 HTML 就得複製一份沒人看守、必然漂移的樣式副本。
- **`Base.astro`**：`<title>` 改成 `Random Dice 2 wiki | 分頁名`（站名在前），加 `<link rel="canonical">`。新增 `noIndex` prop，目前只有 404 頁用——它會省略 canonical **與 og:url**，改輸出 `<meta name="robots" content="noindex">`。

## noIndex 為什麼連 og:url 一起省

`dist/404.html` 是 Cloudflare Pages 拿來回**每一個**未知路徑的那一份，但 `pageUrl` 固定是 `/404/`。留著 canonical 等於邀請搜尋引擎索引 `/404/`；留著 og:url 則會讓一個失效的分享連結在聊天室展開成「我代表 /404/」的預覽卡。兩者都必須不存在。

## 測試

新增 `tests/e2e/seo.spec.ts` 10 條（E2E 85 → 105 passed），改掉 `tree.spec.ts` 的舊 title 斷言。五條防線都用反例確認過會紅：拿掉 canonical、拿掉 og:url 的 gate、刪 `404.astro`、刪 `robots.txt` 各自讓對應的那條紅。

⚠️ **SEO-5「未知路徑回 404」在本機是假綠**：E2E 的 webServer 是 `serve dist`，它對找不到的檔案本來就回 404，`dist/404.html` 存不存在都一樣。soft 404 是 Cloudflare Pages 那端的行為，真正的驗收只能在部署後對正式站 `curl`。這一點寫進了測試註解與 `CLAUDE.md`。

## 資料零變更

`src/generated/tree.json` 與 main 逐位元組相同（`a049e058…`），tree.json gzip 預算不受影響。
