### PR TITLE
fix: 詳情卡片改為置中節點上下方並避開前置鏈

### DIFF
--- a/src/components/NodeDetail.ts
+++ b/src/components/NodeDetail.ts
@@ -68,21 +68,33 @@ function nodeBody(
     ? cumulativeUpgradeCost(upgradeCostTable, node.maxLevel)
     : null;
 
+  // 兩欄：左欄是「這個節點是什麼」，右欄是「要花多少才走得到」，
+  // 最後那句重置警告（spec §2.1 強制要求，永遠是卡片最後一段）**跨兩欄**放底部——
+  // 它是三段裡最長的一句，塞在右欄會把整張卡片撐高、左欄底下留一大塊空白。
+  // ⚠️ 分欄是**版面**不是內容，所以只加兩層 <div>、由 CSS 決定要不要真的並排
+  //（桌機兩欄、手機仍是一欄，見 src/pages/tree.astro 的媒體查詢）。
+  // 原本兩段之間的 <hr> 拿掉了：並排之後那條橫線會橫跨兩欄、切在莫名其妙的位置，
+  // 分隔改由 .chain 的左框線（手機是上框線）給。
   return `
-    <p class="meta">${BRANCH_ZH[node.branch]} · ${typeLabel(node)} · ${escapeHtml(formatUnlockVia(node))}</p>
-    ${node.maxLevel > 1 ? `<p class="meta">等級上限 ${node.maxLevel}</p>` : ''}
-    ${maxUpgrade ? `<p class="upgrade">練滿 ${node.maxLevel} 級累計 ${escapeHtml(formatCost(maxUpgrade))}<span class="cond">含解鎖那一次</span></p>` : ''}
-    ${growth ? `<p class="growth">${escapeHtml(growth)}</p>` : ''}
-    ${node.dataIssue === 'placeholder' ? '<p class="warn">數值待補（遊戲資料含未替換佔位符）</p>' : ''}
-    <p class="desc">${desc}</p>
-    ${node.awakening ? `<button type="button" class="awakening-link" data-detail-awakening>骰子覺醒<span class="cond">${AWAKENING_CONDITION}</span><span class="chev" aria-hidden="true">›</span></button>` : ''}
-    <hr>
-    <h3>前置鏈（${sel.chain.size} 個節點）</h3>
-    <p class="cost">${formatCost(sel.cost)}</p>
-    <p class="note">此為 AND 假設下的上限值，不含強化費用。</p>
-    ${sel.skipped.length > 0 ? `<p class="note">已排除 ${sel.skipped.length} 個非成本解鎖節點</p>` : ''}
-    ${sel.hiddenByFilter > 0 ? `<p class="note">含 ${sel.hiddenByFilter} 個被篩選隱藏的前置</p>` : ''}
-    <p class="note">⚠️ 骰子樹重置需要初期化券，且有已解鎖骰子消失的災情回報，重置前請先確認。</p>
+    <div class="node-body">
+      <div class="col">
+        <p class="meta">${BRANCH_ZH[node.branch]} · ${typeLabel(node)} · ${escapeHtml(formatUnlockVia(node))}</p>
+        ${node.maxLevel > 1 ? `<p class="meta">等級上限 ${node.maxLevel}</p>` : ''}
+        ${maxUpgrade ? `<p class="upgrade">練滿 ${node.maxLevel} 級累計 ${escapeHtml(formatCost(maxUpgrade))}<span class="cond">含解鎖那一次</span></p>` : ''}
+        ${growth ? `<p class="growth">${escapeHtml(growth)}</p>` : ''}
+        ${node.dataIssue === 'placeholder' ? '<p class="warn">數值待補（遊戲資料含未替換佔位符）</p>' : ''}
+        <p class="desc">${desc}</p>
+        ${node.awakening ? `<button type="button" class="awakening-link" data-detail-awakening>骰子覺醒<span class="cond">${AWAKENING_CONDITION}</span><span class="chev" aria-hidden="true">›</span></button>` : ''}
+      </div>
+      <div class="col chain">
+        <h3>前置鏈（${sel.chain.size} 個節點）</h3>
+        <p class="cost">${formatCost(sel.cost)}</p>
+        <p class="note">此為 AND 假設下的上限值，不含強化費用。</p>
+        ${sel.skipped.length > 0 ? `<p class="note">已排除 ${sel.skipped.length} 個非成本解鎖節點</p>` : ''}
+        ${sel.hiddenByFilter > 0 ? `<p class="note">含 ${sel.hiddenByFilter} 個被篩選隱藏的前置</p>` : ''}
+      </div>
+      <p class="note reset-warn">⚠️ 骰子樹重置需要初期化券，且有已解鎖骰子消失的災情回報，重置前請先確認。</p>
+    </div>
   `;
 }
 

--- a/src/pages/tree.astro
+++ b/src/pages/tree.astro
@@ -602,6 +602,11 @@ const TYPES: Array<[string, string]> = [
       width: 100%;
       max-width: 100%;
       max-height: 55vh;
+      /* 桌機卡片 2026-08-23 縮了一級（寬 18rem、內距 --space-3、字級 --fs-md），
+         那是為了「浮在節點正上方時不要壓迫」。手機抽屜是全寬、貼在螢幕底部，沒有那個
+         問題，字再縮只會更難讀——這裡還原成原本的內距與字級。 */
+      padding: var(--space-4);
+      font-size: var(--fs-base);
       border: none;
       border-top: 1px solid var(--border);
       border-radius: 0;
@@ -618,6 +623,24 @@ const TYPES: Array<[string, string]> = [
          現在改成讓抽屜的**可視方框**就停在 chip 列上方（`bottom: var(--chips-h)`）：
          不管捲到哪裡，面板裡的任何一個像素都不會落進 chip 列。這也是 CLAUDE.md 那條
          「不要再引入新的固定偏移量」的同一個教訓——量出來的值，不是猜出來的值。 */
+    }
+    /* 標題與成本那兩行也還原：它們是**粗體中文**，桌機版降到 --fs-base 已經是下限
+       （小字粗體中文的橫筆畫會連成一條，見 CLAUDE.md），手機抽屜沒有縮的理由。 */
+    #detail .view-head h2,
+    #detail .cost {
+      font-size: var(--fs-lg);
+    }
+    /* 桌機的橫式兩欄在手機上不成立：全寬抽屜再分兩欄，每欄只剩約 180px，
+       「核心 34 ＋ 金幣 117,000」這種一行就會折成三行。回到單欄，分隔線改成橫的。 */
+    #detail .node-body {
+      grid-template-columns: 1fr;
+      gap: var(--space-3);
+    }
+    #detail .node-body > .chain {
+      border-left: none;
+      padding-left: 0;
+      border-top: 1px solid var(--border);
+      padding-top: var(--space-3);
     }
     /* 手機版篩選抽屜：**留在 #toolbar 的正常流程裡**，收起就不存在、展開就接在工具列下面。
        不用 position:fixed，也不用任何位移量。

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -124,6 +124,21 @@ let currentSelected: string | null = initialSelected;
 // 根本讀不到這個變數），只有真瀏覽器會炸。
 let upgradeRaf = 0;
 
+// 置中平移的 rAF 控制碼，以及卡片擺在節點的哪一邊。⚠️ 宣告提到這裡的理由跟 upgradeRaf 一模
+// 一樣，而且**是實際踩到的**：jumpToBranch()（手機版初始視角，模組初始化階段就會跑）會呼叫
+// cancelCenterPan()，宣告留在函式旁邊時 400×800 與 720×800 都直接
+// `ReferenceError: Cannot access 'centerRaf' before initialization`，整個模組掛掉、詳情面板
+// 永遠是 hidden。1440×900 完全正常——桌機不走 jumpToBranch()，所以只有窄畫面會炸。
+let centerRaf = 0;
+// 卡片放在節點上方還是下方。select() 決定（見 sideLeastCovered()），positionPanel() 與
+// centerOnSelected() 共用同一個值——兩邊各算一次的話，平移目標與實際擺法會對不上。
+let panelSide: 'above' | 'below' = 'above';
+// panelSide 是為了哪一顆節點算的。applyFilter() 每次輸入都會呼叫 select(currentSelected)，
+// 不記這個的話會跟著重算——見 select() 裡的說明。
+let sidePickedFor: string | null = null;
+// 置中平移期間把卡片**釘在終點位置**，不讓它跟著節點跑（見 centerOnSelected()）。
+let panelPinned = false;
+
 /**
  * 高解析升級的批次世代號。跟 `upgradeRaf` 同一個理由提到這裡（見上面那段說明）：
  * `jumpToBranch()` 在模組初始化階段就會呼叫 `maybeUpgradeIcons()`，宣告留在函式旁邊會落進
@@ -192,6 +207,10 @@ if (typeof addEventListener === 'function') {
   addEventListener('scroll', invalidateCanvasMetrics, { capture: true, passive: true });
 }
 svg.addEventListener('pointerdown', invalidateCanvasMetrics);
+// 使用者一碰畫布就放棄進行中的置中平移——兩股力量同時寫 transform 會互相拉扯。
+// 掛在 pointerdown／wheel 上（不是 pointermove）：手勢一開始就該讓位，不必等真的移動。
+svg.addEventListener('pointerdown', cancelCenterPan);
+svg.addEventListener('wheel', cancelCenterPan, { passive: true });
 
 /**
  * 切換 `#tree.shadows`：圖示在畫面上夠大時才畫節點投影（見 src/pages/tree.astro 那條規則的
@@ -272,6 +291,7 @@ function applyReadabilityFloor(): void {
  * 手機都會，見該函式的說明）。
  */
 function jumpToBranch(branch: Branch): void {
+  cancelCenterPan();
   vp.fitTo(data.meta.bounds[branch]);
   applyReadabilityFloor();
   // 同 focusMatches()：程式移動鏡頭後要自己補一次高解析升級。分支按鈕在 <svg> 之外，
@@ -507,7 +527,18 @@ window.addEventListener('keydown', e => {
   // 要等使用者之後剛好又滾一下滑鼠才會補上（code review 找到的真實落差，這裡補齊，讓
   // 「哪些操作會改到可視範圍」跟「該不該檢查要不要升級圖示」這兩件事保持一致，不看操作是
   // 用滑鼠還是鍵盤）。
-  if (moved) maybeUpgradeIcons();
+  if (moved) {
+    // ⚠️ `cancelCenterPan()` 只能放在**確定是平移／縮放按鍵**的這條路上。
+    // 放在 handler 開頭（一度是那樣寫的）會咬到兩件事：
+    // (a) 節點上按 Enter 開卡片時，svg 的 keydown 先跑 openNode() → animatePan() 排好 rAF，
+    //     同一個事件接著冒泡到 window 就把它取消——實測節點停在 x=172 而不是畫面中央 640，
+    //     Enter 這條路等於完全沒有置中（isTypingTarget 只認 INPUT/TEXTAREA/SELECT，
+    //     焦點在 <g class="node"> 上不會被前面那行擋掉）。
+    // (b) 點擊開節點之後 200ms 內按任何一個鍵（Tab、Esc、任一個字母）都會把平移中途掐掉，
+    //     節點卡在半路。
+    cancelCenterPan();
+    maybeUpgradeIcons();
+  }
 });
 
 // --- 點選節點：前置鏈高亮 + 詳情面板 ---
@@ -584,7 +615,75 @@ function select(id: string | null): void {
 
   renderDetail(node, sel, panel, data.meta.glossary, data.meta.upgradeCostTable);
   viewStack = [{ view: { kind: 'node', id }, scrollTop: 0 }];
+  // ⚠️ 只有「真的換了一顆節點」才重算擺法。`applyFilter()` 每次 input 事件都會呼叫
+  // `select(currentSelected)` 重畫高亮（見那裡的註解），跟著重算有兩個問題：
+  // (a) 每打一個字多兩次強制版面計算 ＋ 一次前置鏈模擬，疊在本來就有的 239 節點篩選上；
+  // (b) `sideLeastCovered()` 模擬的是「**置中之後**」的螢幕座標，而篩選這條路徑根本不會
+  //     置中——算出來的擺法描述的是一個不存在的版面。
+  // 順帶讓擺法在打字期間保持穩定，卡片不會邊打字邊上下跳。
+  if (id !== sidePickedFor) {
+    // 兩趟：第一趟只是為了套上 max-height，量到夾制**之後**的真實高度，那是決定「上面還是
+    // 下面比較不擋」的輸入；第二趟才是最終位置。一趟做不到——擺法要用高度算，高度又要先
+    // 擺過一次才量得準。globalCap 的理由見 positionPanel() 的參數說明。
+    panelSide = 'above';
+    positionPanel({ globalCap: true });
+    panelSide = sideLeastCovered(node, sel.chain, panel.getBoundingClientRect().height);
+    sidePickedFor = id;
+  }
   positionPanel();
+}
+
+/**
+ * 卡片要放節點上方還是下方：**實際算一遍兩種擺法各會蓋住幾個前置節點**，取少的那個。
+ *
+ * 為什麼一定要能翻面：五個分支的生長方向不同。1 系往上長、2／3 系往下長、4 系往左、
+ * 5 系往右——「一律放上方」只解掉往上長與左右長的那三系，2／3 系深層節點的前置鏈整條
+ * 在節點**上方**，卡片放上面照樣全蓋住（2026-08-23 實測：固定放上方時 239 顆有 155 顆
+ * 仍有前置鏈被蓋，其中 2108 是 14 個蓋掉 13 個；能翻面之後降到 44 顆、單顆最多 5 個）。
+ *
+ * 為什麼不用「前置節點在上面的多還是下面的多」這種便宜的判斷：分支是扇形展開的，很多節點
+ * 的前置鏈上下都有，而**離得遠的那些根本不在卡片的水平範圍內**，算進去只會把擺法帶偏。
+ * 直接模擬一次就沒有這個誤差，成本也只是幾十次乘法。
+ *
+ * 只比上下、不比左右：左右兩側正是 4／5 系前置鏈延伸的方向，多一個維度只會讓擺法更難
+ * 預期，而上下兩種已經把最壞情況從「整條鏈」壓到「零星一兩顆」。
+ *
+ * 模擬的座標系是**平移置中之後的螢幕座標**（節點會落在 innerWidth/2, targetCenterY）——
+ * 那才是使用者真正看到的版面。使用者座標換算成 CSS px 的比例是
+ * 「根 svg 的 CTM ✕ 畫布自己的縮放」，兩層都要算進去。
+ */
+function sideLeastCovered(node: TreeNode, chain: Set<string>, cardH: number): 'above' | 'below' {
+  const nodeEl = svg.querySelector(`g.node[data-id="${node.id}"] .icon`);
+  if (!nodeEl) return 'above';
+  const n = nodeEl.getBoundingClientRect();
+  const cardW = panel.getBoundingClientRect().width;
+  const topLimit = panelTopLimit();
+  const ppu = (svg.getScreenCTM?.()?.a ?? 1) * vp.scale;
+  const others = [...chain]
+    .filter(id => id !== node.id)
+    .map(id => byId.get(id))
+    .filter((o): o is TreeNode => !!o);
+  if (others.length === 0) return 'above';
+
+  const cx = window.innerWidth / 2;
+  const radius = n.height / 2;
+  const covered = (side: 'above' | 'below'): number => {
+    const cy = targetCenterY(side, cardH, n.height, topLimit);
+    const cardTop = side === 'above' ? cy - radius - GAP - cardH : cy + radius + GAP;
+    const cardBottom = cardTop + cardH;
+    const cardLeft = cx - cardW / 2;
+    const cardRight = cardLeft + cardW;
+    let hit = 0;
+    for (const o of others) {
+      const ox = cx + (o.x - node.x) * ppu;
+      const oy = cy + (o.y - node.y) * ppu;
+      if (ox + radius > cardLeft && ox - radius < cardRight
+        && oy + radius > cardTop && oy - radius < cardBottom) hit++;
+    }
+    return hit;
+  };
+  // 平手維持預設的上方（卡片壓在節點上方時，視線是「先看卡片再往下看樹」，比反過來自然）。
+  return covered('below') < covered('above') ? 'below' : 'above';
 }
 
 /**
@@ -602,29 +701,229 @@ function selectionFor(id: string) {
   return sel;
 }
 
+/** 卡片與節點、卡片與視窗邊界之間的留白（CSS px）。 */
+const GAP = 12;
 /**
- * 把詳情卡片挪到被選節點旁邊（spec 外，2026-08-18 人工檢視回報：卡在右上角時，眼睛要在
- * 「點下去的節點」和「螢幕另一角」之間來回跑）。
+ * 卡片高度的下限（CSS px）。
+ *
+ * 高度上限是「卡片那一側到畫面邊緣還剩多少」，而使用者可以把節點拖到貼著畫面上緣——那時
+ * 上方的空間會趨近 0，照算會把卡片壓成一條看不出是什麼的細縫。低於這個值時寧可換到另一側
+ * （另一側也塞不下才容許重疊，那已經是「整個視窗都放不下」的極端）。
+ */
+const MIN_PANEL_H = 200;
+/**
+ * 置中時多留給卡片的高度（CSS px），約一行的量。
+ *
+ * 不留的話節點會被推到「卡片剛好放得下」的位置，之後卡片只要長高一點點就會超過那一側的
+ * 空間、被 max-height 裁掉而冒出捲軸。實際會長高的情形至少有一個：選好節點後在搜尋框打字，
+ * 卡片多出「含 N 個被篩選隱藏的前置」一行（實測 279.7 → 312.2）。留一行就吸收得掉。
+ */
+const CENTER_SLACK = 40;
+/**
+ * 置中平移時要在節點下方留的空間（CSS px）。
+ *
+ * 卡片放在節點上方，所以「卡片放得下」等於「節點必須夠低」。這個值只用來算卡片的
+ * `max-height` 上限，刻意是**常數**而不是量到的節點高度：節點大小會隨縮放在 9–50 CSS px
+ * 之間變動（見 src/lib/viewport.ts 的 SHADOW_ON_AT_ICON_PX＝50），拿它當上限的話縮放時
+ * 卡片會跟著一格一格改高度。56 蓋得住最大的那一顆。
+ */
+const NODE_ROOM = 56;
+
+/**
+ * 現在是不是窄畫面（手機版底部抽屜）。
+ *
+ * 每次都重新問一次 matchMedia，不用模組頂端那個載入時算一次的 `isMobile`——視窗是會被拉的。
+ */
+function isNarrow(): boolean {
+  return typeof matchMedia === 'function' && matchMedia(NARROW_QUERY).matches;
+}
+
+/**
+ * 卡片與置中平移共用的上界：**工具列下緣**。
+ *
+ * #toolbar 是疊在畫布左上角的固定圖層（搜尋框＋篩選），只看 --nav-h 的話卡片會滑到它底下、
+ * 把搜尋框蓋掉一半。量它的實際下緣而不是再寫一個固定偏移量——這個 repo 的版面偏移量已經
+ * 寫死出過三次 bug（見 CLAUDE.md）。
+ */
+function panelTopLimit(): number {
+  const toolbarEl = document.getElementById('toolbar');
+  return toolbarEl
+    ? toolbarEl.getBoundingClientRect().bottom
+    : parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--nav-h')) || 48;
+}
+
+/** 置中平移的長度。跟 FILTERS_MS／SLIDE_MS 同一個原則：**從 CSS 讀**，不在 JS 寫第二份。 */
+const CENTER_MS = cssMs('--t-med', 200);
+
+/**
+ * 中止進行中的置中平移。
+ *
+ * 使用者一動畫布（拖曳、滾輪、雙指、鍵盤方向鍵）或程式自己搬鏡頭（搜尋跳轉、分支跳轉）時
+ * 都要叫：兩股力量同時寫 transform 的話，畫面會在兩個目標之間來回被拉扯。
+ */
+function cancelCenterPan(): void {
+  if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(centerRaf);
+  centerRaf = 0;
+  // 中途被打斷（使用者自己動畫布）時一定要解除釘住並重新對齊，否則卡片會停在一個
+  // 「本來預定要到、但畫布沒走完」的位置，跟節點對不上而且再也不會自己修正。
+  if (panelPinned) {
+    panelPinned = false;
+    positionPanel();
+  }
+}
+
+/**
+ * 以螢幕座標的位移量做一段緩動平移（easeOutCubic）。
+ *
+ * 逐幀累加**差值**而不是每幀重算絕對位置：`vp.pan()` 收的就是差值，這樣寫不必知道畫布現在
+ * 在哪，也不會跟同一幀裡別的平移互相覆蓋。
+ * `canAnimate()` 為 false（linkedom 測試環境沒有 rAF、或使用者要求減少動態）時直接跳到位。
+ */
+function animatePan(dx: number, dy: number, onDone: () => void): void {
+  // ⚠️ 這裡**不**呼叫 cancelCenterPan()：它會順手解除釘住並重新對齊，而呼叫端正是在
+  // 「卡片剛剛釘到終點」之後才進來的，清掉等於把剛擺好的位置又推回節點現在的位置。
+  // 「取消上一段動畫」由呼叫端在釘住**之前**做。
+  if (!canAnimate() || typeof performance === 'undefined'
+    || (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5)) {
+    vp.pan(dx, dy);
+    onDone();
+    maybeUpgradeIcons();
+    return;
+  }
+  const start = performance.now();
+  let done = 0;
+  const step = (now: number): void => {
+    const t = Math.min(1, (now - start) / CENTER_MS);
+    const eased = 1 - (1 - t) ** 3;
+    vp.pan(dx * (eased - done), dy * (eased - done));
+    done = eased;
+    if (t < 1) {
+      centerRaf = requestAnimationFrame(step);
+      return;
+    }
+    centerRaf = 0;
+    onDone();
+    // 鏡頭一動就會有新的節點進到畫面裡，它們還掛著 sprite 的低解析 pattern（放大後會糊）。
+    // maybeUpgradeIcons() 平常只掛在 wheel／pointerup 上，程式自己移動鏡頭時不會被觸發——
+    // 跟 focusMatches() 末尾那一行同一個理由。
+    maybeUpgradeIcons();
+  };
+  centerRaf = requestAnimationFrame(step);
+}
+
+/**
+ * 節點平移置中之後，它的垂直中心該落在哪（螢幕 CSS px）。
+ *
+ * 基準是「工具列下緣 → 視窗底部」的中央；卡片那一側放不下時，把節點往卡片的**反**方向
+ * 推到剛好放得下為止（需求卡驗收 3：卡片完整顯示且不蓋到節點），能不動就不動。
+ * `sideLeastCovered()` 也用同一個函式模擬兩種擺法，兩邊算出來的版面才會一致。
+ */
+function targetCenterY(
+  side: 'above' | 'below',
+  cardH: number,
+  nodeH: number,
+  topLimit: number,
+): number {
+  const center = (topLimit + window.innerHeight) / 2;
+  const need = GAP + cardH + CENTER_SLACK;
+  const lo = topLimit + GAP + nodeH / 2 + (side === 'above' ? need : 0);
+  const hi = window.innerHeight - GAP - nodeH / 2 - (side === 'below' ? need : 0);
+  // 兩邊擠不下時（極矮的視窗）以「卡片完整顯示」為優先，讓節點貼到另一側的邊。
+  if (hi < lo) return side === 'above' ? hi : lo;
+  return Math.min(Math.max(center, lo), hi);
+}
+
+/**
+ * 把目前選取的節點平移到畫面中央，讓卡片那一側空出一整塊。
+ *
+ * ⚠️ 刻意**不放進 `select()`**：`applyFilter()` 每次都會呼叫 `select(currentSelected)` 來重畫
+ * 高亮（見那裡的註解），放進去的話使用者在搜尋框每打一個字鏡頭就飛一次。這裡只掛在真正的
+ * 「開啟一個節點」動線上：畫布點擊、鍵盤 Enter、以及 `?node=` 進站。
+ *
+ * 垂直目標是「工具列下緣 → 視窗底部」的中央；卡片比那個位置上方的空間還高時，把節點再往下
+ * 推到「卡片剛好放得下」為止（需求卡驗收 3：卡片完整顯示且不蓋到節點）。水平目標就是視窗
+ * 中央——側欄只是左上角一小塊浮層，畫布本身是整個視窗寬。
+ */
+function centerOnSelected(): void {
+  if (isNarrow() || panel.hidden || !currentSelected) return;
+  // 上一段還在跑就先收乾淨（含解除釘住），再重新量、重新釘。
+  cancelCenterPan();
+  const nodeEl = svg.querySelector(`g.node[data-id="${currentSelected}"] .icon`);
+  if (!nodeEl) return;
+
+  const topLimit = panelTopLimit();
+  const n = nodeEl.getBoundingClientRect();
+  // ⚠️ 要的是卡片的**自然高度**（只受整個可視區限制），不是它現在被那一側空間裁過的高度。
+  // 節點此刻還在平移前的位置，那一側可能只剩一點空間；拿被裁過的高度算目標，平移完卡片
+  // 長回自然高度就又會壓到節點——正是 2026-08-23 code review 抓到的那一族問題。
+  positionPanel({ globalCap: true });
+  const height = panel.getBoundingClientRect().height;
+
+  const target = {
+    cx: window.innerWidth / 2,
+    cy: targetCenterY(panelSide, height, n.height, topLimit),
+  };
+  // ⚠️ 卡片**先跳到終點**，然後整段動畫只有畫布在走。
+  // 讓卡片跟著節點一起滑看起來才「對」，但實際上不行：動畫途中節點還在畫面上緣附近，
+  // 卡片被 top 的夾制壓在工具列下方、跟節點重疊，等節點降下來才彈回貼齊——2026-08-23
+  // 實測那段垂直間距從 −50px 一路爬到 +12px，就是 Yuki 回報的「移動的動畫會閃爍」的另一半。
+  // 釘住之後卡片一次到位、只有樹在底下滑進來，是安靜的。
+  positionPanel({ nodeCenter: target });
+  panelPinned = true;
+  animatePan(
+    target.cx - (n.left + n.width / 2),
+    target.cy - (n.top + n.height / 2),
+    () => {
+      panelPinned = false;
+      positionPanel();
+    },
+  );
+}
+
+/** 「使用者開啟了一個節點」：選取 ＋ 把鏡頭帶過去。`id` 為 null 時就只是清掉選取。 */
+function openNode(id: string | null): void {
+  select(id);
+  if (id !== null) centerOnSelected();
+}
+
+/**
+ * 把詳情卡片挪到被選節點**正上方**（2026-08-23 Yuki 指定；在那之前是「貼在節點左右兩側，
+ * 右邊放不下就翻左邊」）。
+ *
+ * 為什麼不再左右擺：左右兩側正是前置鏈延伸出去的方向。2 系與 4 系長在畫布左半邊，深層節點
+ * 的前置鏈整條往**右**長，而卡片預設就開在右邊——實測 `?node=4112`，9 個前置鏈節點有 7 個
+ * 被卡片蓋住。翻面只是把問題丟給另一邊（1 系與 3 系反過來），真正沒有鏈的方向是上下。
+ * 搭配 `centerOnSelected()`（選取時把節點平移到畫面中央）之後，節點上方永遠有一整塊空地。
  *
  * 只在桌機做。手機版的 #detail 是從螢幕底部升起的抽屜（見 src/pages/tree.astro 的媒體
  * 查詢），窄螢幕上根本沒有「節點旁邊」這種空間，硬擠只會兩邊都看不清。
  *
- * 位置規則：預設放在節點右邊；右邊放不下就翻到左邊；再放不下就夾回可視範圍內。垂直方向
- * 對齊節點中心，同樣夾在工具列下緣與視窗底部之間。這幾個夾制不是防禦性程式碼——樹的四個
- * 角落本來就有節點，不夾就會有卡片一半在畫面外的情況。
+ * 位置規則：卡片**下緣**貼節點上緣（GAP），水平**中心**對齊節點中心；兩個方向都夾回可視
+ * 範圍內，水平還要避開 #branch-nav 側欄。這幾個夾制不是防禦性程式碼——樹的四個角落本來就
+ * 有節點，而使用者可以把畫布拖到任何位置，不夾就會有卡片一半在畫面外的情況。
  */
 /**
  * @param opts.assumeHeight 用這個高度算位置，而不是量卡片現在的高度。
  *   換頁時用：高度正在動畫中，要先把**終點**的位置寫進 `top`，讓 top 與 height 同時跑完，
- *   卡片的垂直中心才會固定不動（＝「上下往中間收」而不是「往上收」）。
+ *   卡片的**下緣**才會固定不動（＝「往上收」而不是「往下掉一截再回來」）。
+ * @param opts.nodeCenter 用這個螢幕座標當節點中心，而不是量節點現在在哪。
+ *   置中平移開始前用：先把卡片放到**平移結束後**該在的位置，整段動畫就只有畫布在動。
+ *   傳了這個參數也代表「我知道自己在做什麼」，會蓋過 panelPinned 的早退。
+ * @param opts.globalCap 高度上限改用「整個可視區」算，而不是「卡片那一側剩多少空間」。
+ *   `select()` 量自然高度時用：那一刻節點還在平移前的位置，用當下的側邊空間算會量到一個
+ *   被壓扁的高度，而置中的目標位置正是拿那個高度算的——目標會算錯，平移完卡片再長回來就
+ *   又壓到節點了。
  */
-function positionPanel(opts: { assumeHeight?: number } = {}): void {
+function positionPanel(opts: {
+  assumeHeight?: number;
+  nodeCenter?: { cx: number; cy: number };
+  globalCap?: boolean;
+} = {}): void {
   // 這裡刻意**不用**模組頂端那個 isMobile：它在載入時算一次就定案，而視窗是會被拉的。
   // 桌機視窗拉窄到斷點以下時，CSS 會把面板切成底部抽屜（inset: auto 0 0 0），但這裡留下的
   // 行內 left/top 優先級更高，抽屜會被釘在桌機算出來的位置上（code review 實測：400×800 下
   // 面板停在 top=162、left=12、寬 400，右邊突出畫面外）。每次都重新問一次媒體查詢才對。
-  const narrow = typeof matchMedia === 'function' && matchMedia(NARROW_QUERY).matches;
-  if (narrow) {
+  if (isNarrow()) {
     panel.style.left = '';
     panel.style.top = '';
     panel.style.right = '';
@@ -632,19 +931,14 @@ function positionPanel(opts: { assumeHeight?: number } = {}): void {
     return;
   }
   if (panel.hidden || !currentSelected) return;
+  // 置中平移進行中：卡片已經放在終點，不要每幀再跟著節點算一次（見 centerOnSelected()）。
+  if (panelPinned && !opts.nodeCenter) return;
   const nodeEl = svg.querySelector(`g.node[data-id="${currentSelected}"] .icon`);
   if (!nodeEl) return;
 
-  const GAP = 12;
-  // 上緣夾在**工具列**下方：#toolbar 是疊在畫布左上角的固定圖層（搜尋框＋篩選），只看
-  // --nav-h 的話卡片會滑到它底下、把搜尋框蓋掉一半。量它的實際下緣而不是再寫一個固定
-  // 偏移量——這個 repo 的版面偏移量已經寫死出過三次 bug（見 CLAUDE.md）。
-  const toolbarEl = document.getElementById('toolbar');
-  const topLimit = toolbarEl
-    ? toolbarEl.getBoundingClientRect().bottom
-    : parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--nav-h')) || 48;
+  const topLimit = panelTopLimit();
 
-  // 左緣還要避開 #branch-nav 側欄。只避 #toolbar 是不夠的：側欄比工具列矮但更長，760px 寬時
+  // 左右緣要避開 #branch-nav 側欄。只避 #toolbar 是不夠的：側欄比工具列矮但更長，760px 寬時
   // 卡片會被夾到 left=12，正好壓在側欄按鈕上並攔截點擊（實測 760×800：#detail 12–364 /
   // 158.91–549.28，#branch-nav 0–79.19 / 146.91–356.75，兩個矩形相交）。
   //
@@ -658,15 +952,53 @@ function positionPanel(opts: { assumeHeight?: number } = {}): void {
   // 下緣（低了約 68px），兩邊基準不一致時面板下緣會超出視窗——而面板最後一段固定是 spec
   // §2.1 強制要求的「重置需要初期化券」災情警告，捲到底也看不到（code review 實測 1000×480
   // 下超出 43.8px）。先設上限、再量高度，量到的才是夾制後的結果。
-  panel.style.maxHeight = `${Math.max(0, window.innerHeight - topLimit - GAP * 2)}px`;
+  //
+  const now = nodeEl.getBoundingClientRect();
+  // 節點的「盒子」：尺寸一律用量到的（跟著縮放走），位置可以被 nodeCenter 換成終點座標。
+  const n = opts.nodeCenter
+    ? {
+        top: opts.nodeCenter.cy - now.height / 2,
+        bottom: opts.nodeCenter.cy + now.height / 2,
+        left: opts.nodeCenter.cx - now.width / 2,
+        width: now.width,
+        height: now.height,
+      }
+    : now;
 
-  const n = nodeEl.getBoundingClientRect();
+  // 高度上限。基準是工具列下緣而不是 --nav-h：CSS 的 max-height 用 --nav-h 起算，但實際起點
+  // 低了約 68px，兩邊基準不一致時面板下緣會超出視窗——而面板最後一段固定是 spec §2.1 強制
+  // 要求的「重置需要初期化券」災情警告，捲到底也看不到（code review 實測 1000×480 下超出
+  // 43.8px）。先設上限、再量高度，量到的才是夾制後的結果。
+  //
+  // ⚠️ 上限用的是**卡片那一側到畫面邊緣還剩多少**，不是整個視窗的高度。
+  // 用整窗高度算的話，卡片只要長到超過那一側的空間，下面的夾制就會把它推到節點身上——
+  // 2026-08-23 code review 實測：選好節點後在搜尋框打一個字，卡片多出「含 N 個被篩選隱藏
+  // 的前置」一行（279.7 → 312.2），四顆抽樣節點有三顆被卡片完全蓋住（重疊 467.6 px²）。
+  // 那條路徑不會重新置中（刻意的，見 centerOnSelected() 的註解），所以只能靠上限自己收斂。
+  const roomAbove = n.top - topLimit - GAP * 2;
+  const roomBelow = window.innerHeight - n.bottom - GAP * 2;
+  // 偏好側連 MIN_PANEL_H 都放不下、而另一側放得下時，這一次先讓到另一側。
+  // ⚠️ opts.globalCap（select() 量自然高度時用）走的是另一條路：那時節點還沒平移到定位，
+  // 拿當下的空間算會量到一個被壓扁的高度，而置中的目標位置正是用那個高度算出來的。
+  const side: 'above' | 'below' = !opts.globalCap
+    && (panelSide === 'above' ? roomAbove : roomBelow) < MIN_PANEL_H
+    && (panelSide === 'above' ? roomBelow : roomAbove) >= MIN_PANEL_H
+    ? (panelSide === 'above' ? 'below' : 'above')
+    : panelSide;
+  // 置中之後那一側必定放得下自然高度（見 targetCenterY()），所以這個上限在正常動線上不會
+  // 真的裁到卡片；它只在使用者把節點拖到畫面邊緣、或內容變高之後才生效。
+  const globalCap = Math.max(0, window.innerHeight - topLimit - GAP * 3 - NODE_ROOM);
+  const sideRoom = Math.max(MIN_PANEL_H, side === 'above' ? roomAbove : roomBelow);
+  panel.style.maxHeight = `${opts.globalCap ? globalCap : Math.min(globalCap, sideRoom)}px`;
+
   const rect = panel.getBoundingClientRect();
   const height = opts.assumeHeight ?? rect.height;
   const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(v, hi));
 
+  // 垂直：卡片下緣貼節點上緣（above），或卡片上緣貼節點下緣（below）。
+  // 夾制的下界是工具列下緣、上界是「卡片整張還留在視窗內」。
   const top = clamp(
-    n.top + n.height / 2 - height / 2,
+    side === 'below' ? n.bottom + GAP : n.top - GAP - height,
     topLimit + GAP,
     Math.max(topLimit + GAP, window.innerHeight - height - GAP),
   );
@@ -680,9 +1012,8 @@ function positionPanel(opts: { assumeHeight?: number } = {}): void {
   // 把卡片推出視窗——看不到比被壓住更糟。
   const leftLimit = Math.min(overlapsSidebar ? Math.max(GAP, obstacle!.right + GAP) : GAP, rightLimit);
 
-  let left = n.right + GAP;
-  if (left + rect.width > window.innerWidth - GAP) left = n.left - GAP - rect.width;
-  left = clamp(left, leftLimit, rightLimit);
+  // 水平：中心對齊節點中心。
+  const left = clamp(n.left + n.width / 2 - rect.width / 2, leftLimit, rightLimit);
 
   panel.style.left = `${left}px`;
   panel.style.top = `${top}px`;
@@ -710,8 +1041,17 @@ function schedulePositionPanel(): void {
     positionPanel();
     return;
   }
-  cancelAnimationFrame(positionRaf);
-  positionRaf = requestAnimationFrame(() => positionPanel());
+  // ⚠️ 「已經排了就不要再排」，**不可以**寫成 cancelAnimationFrame() ＋ 重排。
+  // 兩者都是「一幀最多做一次」，但取消重排會被**每幀都寫 transform** 的來源餓死：
+  // 排好的回呼還沒輪到執行就被下一次寫入取消，如此循環，卡片一次都不會重新定位。
+  // 2026-08-23 實測：置中平移（每幀寫一次）期間卡片完全不動，節點滑走 468px 之後卡片
+  // 在最後一幀瞬移到位——那就是 Yuki 回報的「移動的動畫會閃爍」。
+  // 拖曳看不出來只是因為 pointermove 沒有真的每幀都來（實測錯位最多 12px）。
+  if (positionRaf) return;
+  positionRaf = requestAnimationFrame(() => {
+    positionRaf = 0;
+    positionPanel();
+  });
 }
 if (typeof MutationObserver === 'function') {
   // 包一層而不是直接把 schedulePositionPanel 當 callback：它現在收一個 options 物件，
@@ -756,7 +1096,7 @@ svg.addEventListener('pointerup', e => {
   if (touches.size > 0) return;
   const moved = Math.hypot(e.clientX - downPos.x, e.clientY - downPos.y);
   if (moved > DRAG_THRESHOLD_PX) return;
-  select(downTarget ? downTarget.getAttribute('data-id') : null);
+  openNode(downTarget ? downTarget.getAttribute('data-id') : null);
 });
 
 // Enter／Esc 掛在 svg 上而不是 window：keydown 事件要先冒泡經過 svg 才會觸發這裡，
@@ -765,7 +1105,7 @@ svg.addEventListener('pointerup', e => {
 // 詳情面板，可以留給搜尋框自己處理「清空搜尋」。
 svg.addEventListener('keydown', e => {
   const g = (e.target as Element).closest?.('g.node');
-  if (e.key === 'Enter' && g) select(g.getAttribute('data-id'));
+  if (e.key === 'Enter' && g) openNode(g.getAttribute('data-id'));
   if (e.key === 'Escape') select(null);
 });
 
@@ -866,6 +1206,7 @@ function updateFilterStatus(matchCount: number): void {
 function focusMatches(): void {
   const matched = matchedNodes();
   if (matched.length === 0) return;
+  cancelCenterPan();
   const xs = matched.map(n => n.x);
   const ys = matched.map(n => n.y);
   const PAD = 90;
@@ -1152,7 +1493,12 @@ function slide(fromEl: HTMLElement, toEl: HTMLElement, dir: 'forward' | 'back', 
   fromEl.classList.add('sliding');
   toEl.classList.remove('sliding');
   const toH = stack.offsetHeight || fromH;
-  const toPanelH = panel.offsetHeight;
+  // ⚠️ 用 getBoundingClientRect().height 不用 offsetHeight：後者**四捨五入成整數**
+  // （實測 280 vs 實際 279.7）。這個值是動畫終點餵給 positionPanel() 的高度，差 0.3px 就會
+  // 讓卡片在動畫最後一格越過落定位置、再被收尾的重新定位拉回來——肉眼看不到，但那是一次
+  // 真正的反向，Z4 的「不反向」斷言（門檻 0.3px）會直接紅。
+  // 2026-08-23 兩欄版面把自然高度從 280 改成 279.7，剛好把這個既有的取整誤差推過門檻。
+  const toPanelH = panel.getBoundingClientRect().height;
   toEl.classList.add('sliding');
 
   const enter = dir === 'forward' ? 100 : -100;
@@ -1410,3 +1756,8 @@ applyFilter();
 // 網址帶了搜尋字串就把鏡頭帶到命中的節點上。分享連結（或按下重新整理）本來就是在說
 // 「看這些」，落在原本的初始視角只會看到一片灰，跟點關鍵字時的死路一模一樣。
 if (filterState.query.trim() !== '') focusMatches();
+// `?node=` 進站也要置中——分享連結指名了一顆節點，它落在初始視角的哪個角落是隨機的。
+// 順序在 focusMatches() **之後**：兩個參數同時出現時，指名的那顆節點比「命中的那一群」具體。
+// 選取本身是上面 applyFilter() 內部的 select(currentSelected) 做掉的（見那裡的註解），
+// 這裡只補鏡頭；centerOnSelected() 自己會在窄畫面／沒有選取時直接返回。
+centerOnSelected();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -352,7 +352,13 @@ pre {
      有圓角與陰影，高度只包到內容為止（撐滿時才捲動）。留白讓底下的骰子樹在卡片邊緣
      露出來，看得出來它是疊在畫布上的一層，而不是把畫布切掉一塊。 */
   right: 0.75rem;
-  width: 22rem;
+  /* 2026-08-23 兩次調整：先從 22rem 縮到 18rem（「整體縮小」），再改成**橫式兩欄**、
+     寬度放到 32rem（Yuki：「在上方還是直立長方形有點奇怪，可以改成橫的」）。
+     卡片浮在節點正上方／正下方時，直立的長方形會往上戳很高、把樹切成兩半；橫的貼著節點
+     鋪開，遮住的是一條扁帶。內距與字級維持降一級後的值。
+     ⚠️ 這幾處都只給桌機：手機版是全寬、從底部升起的抽屜，兩欄與縮小都不適用，
+     src/pages/tree.astro 的 max-width: 720px 那一段把它們還原回去。 */
+  width: 32rem;
   max-width: calc(100% - 1.5rem);
   max-height: calc(100vh - var(--nav-h, 3rem) - 1.5rem);
   /* x 一定要明確設成 hidden：視圖堆疊的動畫會把滑入／滑出的那張推到內容區左右兩側，
@@ -361,7 +367,8 @@ pre {
   overflow-x: hidden;
   overflow-y: auto;
   background: var(--surface-2);
-  padding: var(--space-4);
+  padding: var(--space-3);
+  font-size: var(--fs-md);
   border: 1px solid var(--border-strong);
   border-radius: var(--r-md);
   box-shadow: var(--shadow-3);
@@ -380,9 +387,36 @@ pre {
   color: var(--muted);
   font-size: var(--fs-xs);
 }
+/* 節點視圖的兩欄版面。只有節點視圖有 .node-body——關鍵字頁與覺醒頁是單純一段解釋，
+   分欄只會讓一句話被劈成兩半。 */
+#detail .node-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+}
+/* 分隔線走框線不走 <hr>：<hr> 是一個佔一整列的區塊元素，並排之後它會橫跨兩欄。 */
+#detail .node-body > .chain {
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+}
+/* 重置警告跨兩欄。它是最後一段、也是最長的一句，留在右欄會把卡片撐高一截。 */
+#detail .node-body > .reset-warn {
+  grid-column: 1 / -1;
+  margin-bottom: 0;
+}
+/* 兩欄之後，每一欄第一個元素的上邊界外距會讓兩欄的第一行對不齊（h3 有預設 margin-top，
+   p 沒有）。歸零讓兩欄從同一條基線開始。 */
+#detail .node-body > .col > :first-child {
+  margin-top: 0;
+}
+#detail .node-body h3 {
+  margin-bottom: var(--space-2);
+}
 #detail .cost {
   color: var(--gold);
-  font-size: var(--fs-lg);
+  /* ⚠️ 不能再往下降：這是粗體中文（「核心」「金幣」），小字粗體中文的橫筆畫在沒有真 CJK
+     bold 字面的環境會連成一條橫線（見 CLAUDE.md）。--fs-base 是安全的下限。 */
+  font-size: var(--fs-base);
   font-weight: 700;
 }
 /* --- 詳情面板的視圖堆疊（2026-08-20）---
@@ -399,9 +433,12 @@ pre {
 #detail .stack.animating {
   transition: height var(--slide-ms) var(--slide-ease);
 }
-/* 換頁時 top 也要跟著動，卡片的垂直中心才不會漂——高度從 401 縮到 198 而 top 不動的話，
-   卡片是「往上收」而不是「上下往中間收」。這條 transition **只在換頁期間掛上**：
-   拖曳畫布時卡片是每一幀重寫 top 來跟著節點跑，那時候有 transition 會整個變成拖尾。 */
+/* 換頁時 top 也要跟著動，卡片貼著節點的那一緣才不會漂。
+   ⚠️ 2026-08-23 卡片改成擺在節點上方／下方之後，這條要守的東西換了：
+   放上方時卡片下緣貼著節點，高度從 401 縮到 198 而 top 不動的話，下緣會往上跳 203px、
+   跟節點之間裂出一道縫（放下方時 top 本來就不隨高度變，這條 transition 只是無害地空轉）。
+   這條 transition **只在換頁期間掛上**：拖曳畫布時卡片是每一幀重寫 top 來跟著節點跑，
+   那時候有 transition 會整個變成拖尾。 */
 #detail.panel-sliding {
   transition: top var(--slide-ms) var(--slide-ease);
 }
@@ -437,7 +474,8 @@ pre {
 #detail .view-head h2 {
   grid-column: 2;
   margin: 0;
-  font-size: var(--fs-lg);
+  /* 同 .cost：粗體中文的下限是 --fs-base。 */
+  font-size: var(--fs-base);
   overflow-wrap: anywhere;
 }
 #detail .view-back,

--- a/tests/e2e/tree.spec.ts
+++ b/tests/e2e/tree.spec.ts
@@ -841,29 +841,42 @@ test('M. 標籤只在需要時出現：符文／被動預設不標字，選進�
   await expect(offChain.first().locator('.label')).toBeHidden();
 });
 
-test('N. 詳情卡片貼在被選節點旁邊，不擋工具列，畫布平移時跟著走', async ({ page, isMobile }) => {
+test('N. 選節點時鏡頭置中、卡片貼在節點上方或下方，不擋工具列，畫布平移時跟著走', async ({ page, isMobile }) => {
   test.skip(isMobile, '僅桌機：手機版 #detail 是從底部升起的抽屜，沒有「節點旁邊」這種空間');
+  // 2026-08-23 改版：卡片從「貼在節點左右兩側」改成「節點平移置中 ＋ 卡片貼在節點上方或
+  // 下方」。左右兩側正是前置鏈延伸出去的方向，卡片開在那裡會把剛剛高亮起來的鏈整條蓋掉
+  // （見 N2）。這條守的是新版面的三個形狀：置中、垂直緊鄰、水平中心對齊。
   await page.goto('/tree?node=1002');
   const panel = page.locator('#detail');
   const icon = page.locator('g.node[data-id="1002"] .icon');
   await expect(panel).toBeVisible();
 
+  // ⚠️ 一定要 poll：置中是一段約 200ms 的緩動平移，goto 回來的當下它多半還在跑，
+  // 直接量 boundingBox 會量到半路的位置（實測會落在目標左邊一兩百 px）。
+  await expect.poll(async () => {
+    const n = (await icon.boundingBox())!;
+    return Math.round(Math.abs((n.x + n.width / 2) - page.viewportSize()!.width / 2));
+  }, { message: '節點應該被平移到畫面水平中央' }).toBeLessThanOrEqual(2);
+
   const p1 = (await panel.boundingBox())!;
   const n1 = (await icon.boundingBox())!;
   const toolbar = (await page.locator('#toolbar').boundingBox())!;
 
-  // 貼在節點旁：水平方向緊鄰（左右都可以，靠近邊緣時會翻面），垂直方向大致對齊節點中心。
-  const gapRight = p1.x - (n1.x + n1.width);
-  const gapLeft = n1.x - (p1.x + p1.width);
-  expect(Math.max(gapRight, gapLeft)).toBeGreaterThanOrEqual(0);
-  expect(Math.max(gapRight, gapLeft)).toBeLessThan(40);
-  expect(Math.abs((p1.y + p1.height / 2) - (n1.y + n1.height / 2))).toBeLessThan(p1.height);
+  // 垂直緊鄰：卡片下緣貼節點上緣，或卡片上緣貼節點下緣（哪一邊由前置鏈決定，見 N2）。
+  const gapAbove = n1.y - (p1.y + p1.height);
+  const gapBelow = p1.y - (n1.y + n1.height);
+  expect(Math.max(gapAbove, gapBelow)).toBeGreaterThanOrEqual(0);
+  expect(Math.max(gapAbove, gapBelow)).toBeLessThan(20);
+  // 水平中心對齊節點中心
+  expect(Math.abs((p1.x + p1.width / 2) - (n1.x + n1.width / 2))).toBeLessThan(2);
   // 不擋工具列
   expect(p1.y).toBeGreaterThanOrEqual(toolbar.y + toolbar.height - 1);
 
-  // 平移畫布後要跟著節點跑——卡片留在原地的話，它就指著一個已經不在那裡的節點了
-  // 起點挑畫布左下角的空白處：卡片本身佔了畫面右上一大塊，從那裡起手等於在拖卡片、
-  // 畫布不會動，測試會變成「前提不成立」的假紅。
+  // 平移畫布後要跟著節點跑——卡片留在原地的話，它就指著一個已經不在那裡的節點了。
+  // ⚠️ 起點挑畫布左半邊的空白處：卡片現在置中（1280 寬時大約佔 x 464–816），從它身上起手
+  // 等於在拖卡片、畫布不會動，測試會變成「前提不成立」的假紅。
+  // 這一下拖曳同時也驗了「使用者一碰畫布就中止置中平移」——沒中止的話兩股力量會互相拉扯，
+  // 下面「與節點的相對位置維持不變」那條會抖出誤差。
   await page.mouse.move(200, 600);
   await page.mouse.down();
   await page.mouse.move(80, 600, { steps: 8 });
@@ -873,6 +886,303 @@ test('N. 詳情卡片貼在被選節點旁邊，不擋工具列，畫布平移�
   expect(n2.x).toBeLessThan(n1.x - 40); // 前提：畫布真的移動了
   expect(p2.x).toBeLessThan(p1.x - 40);
   expect(Math.abs((p2.x - n2.x) - (p1.x - n1.x))).toBeLessThan(4); // 與節點的相對位置維持不變
+
+  // 從畫布上直接點一顆節點也要置中。
+  // ⚠️ 這一段不是重複：`?node=` 進站與畫布點擊是**兩條不同的程式路徑**（前者由模組初始化
+  // 尾端補一次 centerOnSelected()，後者走 openNode()）。上面那組只驗得到前者——實測把
+  // openNode() 裡的 centerOnSelected() 整行刪掉，這條測試在補上這一段之前仍然全綠。
+  await page.goto('/tree');
+  await page.waitForSelector('#tree g.node');
+  // ⚠️ 挑 4112（x=100，整棵樹最左邊那一顆）不挑 1001：1001 在 viewBox 正中央（x=1000），
+  // 桌機預設視角本來就把它擺在畫面中線上，拿它當受測對象的話「有沒有置中」根本量不出差別
+  // ——實測把 centerOnSelected() 刪掉，用 1001 的版本仍然全綠。
+  await page.locator('g.node[data-id="4112"]').click();
+  await expect(page.locator('#detail')).toBeVisible();
+  await expect.poll(async () => {
+    const n = (await page.locator('g.node[data-id="4112"] .icon').boundingBox())!;
+    return Math.round(Math.abs((n.x + n.width / 2) - page.viewportSize()!.width / 2));
+  }, { message: '在畫布上點節點，鏡頭也要把它帶到畫面水平中央' }).toBeLessThanOrEqual(2);
+});
+
+/**
+ * N2. 這一整輪改動存在的理由：卡片不可以蓋住剛剛高亮起來的前置鏈。
+ *
+ * Yuki 2026-08-23 回報：桌機點開骰子資訊時，卡片跟前置鏈都跑到節點右邊，卡片把鏈整條蓋掉。
+ * 全站掃過 239 顆節點的實測數字（1440×900）：
+ *   舊版（卡片貼節點左右）        152 顆節點的前置鏈被蓋，被蓋節點共 749 個，單顆最慘 14/15
+ *   只固定放上方                  155 顆                                     單顆最慘 13/14
+ *   置中 ＋ 上下擇一（現在這版）   44 顆                       共 69 個      單顆最慘  5/14
+ * 「只固定放上方」沒有比較好，因為 2／3 系是**往下長**的，深層節點的前置鏈整條在節點上方。
+ * 所以擺法必須是算出來的（tree-canvas.ts 的 sideLeastCovered()），不是寫死一邊。
+ *
+ * 這裡挑四顆舊版最慘的節點釘死在 0，四個生長方向各一顆：4 系往左、2 系往下、5 系往右、
+ * 以及往左長但深度中等的 4112。
+ * ⚠️ 剩下那 44 顆不是漏掉：分支是扇形展開的，5401／5301／4113 這些節點的前置鏈上下都有，
+ * 沒有任何一側能全避開。這條測試守的是「該歸零的有歸零」，不是「全站零遮擋」。
+ */
+test('N2. 詳情卡片不蓋住前置鏈（這一輪改動的驗收）', async ({ page, isMobile }) => {
+  test.skip(isMobile, '僅桌機：手機版卡片是底部抽屜，本來就不疊在節點上');
+  for (const [id, wasCovered] of [['2304', 14], ['2113', 13], ['5113', 12], ['4112', 7]] as const) {
+    await page.goto(`/tree?node=${id}`);
+    await expect(page.locator('#detail')).toBeVisible();
+    // poll 的理由同 N：置中平移還在跑的時候量到的是半路的位置。
+    await expect.poll(async () => page.evaluate((nid) => {
+      const r = (el: Element) => el.getBoundingClientRect();
+      const p = r(document.getElementById('detail')!);
+      const chain = [...document.querySelectorAll('svg g.node.in-chain .icon')].map(r);
+      const overlap = (c: DOMRect) =>
+        Math.max(0, Math.min(p.right, c.right) - Math.max(p.left, c.left))
+        * Math.max(0, Math.min(p.bottom, c.bottom) - Math.max(p.top, c.top));
+      const icon = document.querySelector(`g.node[data-id="${nid}"] .icon`)!;
+      const centered = Math.abs((r(icon).left + r(icon).width / 2) - window.innerWidth / 2) < 2;
+      // 還沒平移到定位就回一個不可能通過的值，讓 poll 繼續等而不是量到半路的畫面。
+      return centered ? chain.filter(c => overlap(c) > 0).length : -1;
+    }, id), { message: `節點 ${id}（舊版被蓋 ${wasCovered} 個）的前置鏈不該被卡片蓋到` })
+      .toBe(0);
+    // 前提斷言：前置鏈真的有東西可以被蓋。少了它，資料改動讓 .in-chain 變成 0 個時上面會
+    // 自動成立——這個 repo 已經因為「防線其實沒在防」踩過好幾次（見 CLAUDE.md 規則 4）。
+    expect(await page.locator('svg g.node.in-chain').count()).toBeGreaterThan(1);
+  }
+});
+
+/**
+ * N3. 置中平移期間卡片不可以動（Yuki 2026-08-23 回報「移動的動畫會閃爍」）。
+ *
+ * 兩個成因疊在一起，各修一半：
+ * 1. `schedulePositionPanel()` 原本是 `cancelAnimationFrame()` ＋ 重排。平移每一幀都寫
+ *    `#viewport` 的 style，於是排好的重新定位回呼**永遠在執行前就被取消**——卡片整段動畫
+ *    完全不動，最後一幀才瞬移到位（實測水平錯位一路拉到 450px）。改成「已經排了就不再排」。
+ * 2. 就算跟得上，動畫途中節點還在畫面上緣附近，卡片會被 top 的夾制壓在工具列下方、
+ *    跟節點重疊，等節點降下來才彈回貼齊（實測垂直間距 −50px → +12px）。
+ *    所以現在改成**卡片一開始就定在終點**、整段動畫只有畫布在走。
+ *
+ * 這條測試量的是「卡片自己在動畫全程出現過幾個位置」——1 個才對。
+ * ⚠️ 取樣必須在頁面內用 rAF 做（同 Z4）：Playwright 往返一趟 10–20ms，量不到中間格。
+ */
+test('N3. 置中平移期間，卡片一次到位不跟著滑（閃爍修正）', async ({ page, isMobile }) => {
+  test.skip(isMobile, '僅桌機：手機版不做置中平移，卡片是底部抽屜');
+  await page.goto('/tree');
+  await page.waitForSelector('#tree g.node');
+
+  await page.evaluate(() => {
+    const w = window as unknown as { __p: string[]; __n: number[] };
+    w.__p = [];
+    w.__n = [];
+    const tick = () => {
+      const d = document.getElementById('detail')!;
+      const icon = document.querySelector('g.node[data-id="4112"] .icon');
+      if (!d.hidden && icon) {
+        const r = d.getBoundingClientRect();
+        w.__p.push(`${r.left.toFixed(0)},${r.top.toFixed(0)},${r.height.toFixed(0)}`);
+        const n = icon.getBoundingClientRect();
+        w.__n.push(+(n.left + n.width / 2).toFixed(1));
+      }
+      if (w.__p.length < 60) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+  // 挑最左邊那一顆，平移量才夠大（實測要走 468px）。挑靠中間的節點量不出差別。
+  await page.locator('g.node[data-id="4112"]').click();
+  await page.waitForTimeout(1200);
+
+  const { positions, nodeXs } = await page.evaluate(() => {
+    const w = window as unknown as { __p: string[]; __n: number[] };
+    return { positions: w.__p, nodeXs: w.__n };
+  });
+  // 前提斷言：畫布真的走了一大段，而且取樣有涵蓋到動畫期間。少了這兩條，卡片「沒動」
+  // 也可能只是因為根本沒有動畫發生（這個 repo 的假綠已經踩過好幾次，見 CLAUDE.md 規則 4）。
+  expect(positions.length).toBeGreaterThan(20);
+  expect(Math.max(...nodeXs) - Math.min(...nodeXs)).toBeGreaterThan(200);
+
+  expect([...new Set(positions)], '卡片在整段置中平移中只能有一個位置').toHaveLength(1);
+
+  // 第二半：「每幀都寫 transform」的來源不可以把重新定位餓死。
+  // ⚠️ 這一段是獨立的斷言，不是重複：釘住（上面那條）之後，置中平移期間根本不會叫
+  // positionPanel()，所以把 schedulePositionPanel() 改回 cancelAnimationFrame() ＋ 重排，
+  // 上面那條仍然全綠（實測過）。這裡直接裝一個每幀寫入的來源來打那條路徑。
+  // 拖曳測不到：pointermove 沒有真的每幀都來（實測錯位最多 12px，卡片跟得上）。
+  await page.goto('/tree?node=1002');
+  await expect(page.locator('#detail')).toBeVisible();
+  await page.waitForTimeout(500);
+  const offsets = await page.evaluate(async () => {
+    const vpEl = document.getElementById('viewport')!;
+    const m = new DOMMatrixReadOnly(getComputedStyle(vpEl).transform);
+    const out: number[] = [];
+    await new Promise<void>(resolve => {
+      let i = 0;
+      const tick = () => {
+        // 每一幀都寫一次 style.transform，就跟置中平移的寫入頻率一樣。
+        vpEl.style.transform = `translate(${m.e - i * 8}px,${m.f}px) scale(${m.a})`;
+        const icon = document.querySelector('g.node[data-id="1002"] .icon')!;
+        const n = icon.getBoundingClientRect();
+        const p = document.getElementById('detail')!.getBoundingClientRect();
+        out.push(+((p.left + p.width / 2) - (n.left + n.width / 2)).toFixed(1));
+        if (++i < 40) requestAnimationFrame(tick);
+        else resolve();
+      };
+      requestAnimationFrame(tick);
+    });
+    return out;
+  });
+  // 前提：畫布真的被推走了一大段（不然「卡片跟得上」是廢話）。
+  expect(offsets.length).toBeGreaterThan(20);
+  // 卡片最多落後一幀（一幀 8px）。餓死的話它整段不動，錯位會一路累積到 300px 以上。
+  expect(Math.max(...offsets.map(Math.abs)),
+    '每幀都寫 transform 時，卡片的重新定位不可以被餓死').toBeLessThan(20);
+});
+
+/**
+ * N4. 節點卡片在桌機是**橫式兩欄**，在手機仍是單欄。
+ *
+ * Yuki 2026-08-23：「卡片在上方還是直立長方形有點奇怪，可以改成橫的」。卡片浮在節點正上方
+ * 時，直立的長方形會往上戳很高、把樹切成兩半；橫的貼著節點鋪開，遮住的只是一條扁帶。
+ * 版面是純 CSS（`#detail .node-body` 的 grid），沒有任何 JS 會說話——把
+ * `grid-template-columns` 改回 `1fr` 全站測試仍然綠，所以要這一條。
+ */
+test('N4. 節點卡片：桌機橫式兩欄、手機單欄，重置警告跨兩欄', async ({ page, isMobile }) => {
+  await page.goto('/tree?node=1001');
+  await expect(page.locator('#detail')).toBeVisible();
+  await page.waitForTimeout(400); // 置中平移跑完再量
+
+  const m = await page.evaluate(() => {
+    const r = (el: Element) => el.getBoundingClientRect();
+    const d = r(document.getElementById('detail')!);
+    const cols = [...document.querySelectorAll('#detail .node-body > .col')].map(r);
+    const warn = r(document.querySelector('#detail .reset-warn')!);
+    return {
+      w: d.width, h: d.height,
+      tops: cols.map(c => Math.round(c.top)),
+      widths: cols.map(c => c.width),
+      count: cols.length,
+      warnW: warn.width,
+    };
+  });
+
+  // 前提：兩個欄位都在（版面之外，這也守著 NodeDetail.ts 沒有把 .col 拆掉）。
+  expect(m.count).toBe(2);
+
+  if (isMobile) {
+    // 手機是全寬抽屜，分兩欄每欄只剩約 180px：維持上下排。
+    expect(m.tops[0]!, '手機版兩段應該上下排').toBeLessThan(m.tops[1]!);
+  } else {
+    expect(m.tops[0], '桌機版兩欄應該從同一條基線開始').toEqual(m.tops[1]);
+    expect(m.w, '卡片應該是橫的（寬 > 高）').toBeGreaterThan(m.h);
+    // 重置警告跨兩欄：它比單獨一欄寬得多。
+    expect(m.warnW).toBeGreaterThan(m.widths[1]! * 1.5);
+  }
+});
+
+/** 節點中心離視窗水平中線差幾 px（四捨五入）。置中平移是動畫，量之前一律用 expect.poll。 */
+async function centerOffset(page: Page, id: string): Promise<number> {
+  const n = (await page.locator(`g.node[data-id="${id}"] .icon`).boundingBox())!;
+  return Math.round(Math.abs((n.x + n.width / 2) - page.viewportSize()!.width / 2));
+}
+
+/** 卡片與節點的重疊面積（px²）。0 才對——卡片不可以蓋住它正在描述的那顆節點。 */
+function nodeOverlap(page: Page, id: string) {
+  return page.evaluate((nid) => {
+    const p = document.getElementById('detail')!.getBoundingClientRect();
+    const n = document.querySelector(`g.node[data-id="${nid}"] .icon`)!.getBoundingClientRect();
+    const ox = Math.max(0, Math.min(p.right, n.right) - Math.max(p.left, n.left));
+    const oy = Math.max(0, Math.min(p.bottom, n.bottom) - Math.max(p.top, n.top));
+    return {
+      overlap: +(ox * oy).toFixed(1),
+      height: +p.height.toFixed(1),
+      side: p.bottom <= n.top + 1 ? 'above' : 'below',
+    };
+  }, id);
+}
+
+/**
+ * N5. 鍵盤開節點也要置中，而且置中途中按鍵不可以把平移掐掉。
+ *
+ * 2026-08-23 code review 抓到：`window` 的 keydown handler 在**檢查按了什麼鍵之前**就無條件
+ * 呼叫 `cancelCenterPan()`。節點上按 Enter 時，svg 的 keydown 先跑 `openNode()` →
+ * `animatePan()` 排好 rAF，同一個事件冒泡到 window 就把它取消——實測節點停在 x=172 而不是
+ * 畫面中央 640，等於 Enter 這條路完全沒有置中。`isTypingTarget()` 只認 INPUT/TEXTAREA/SELECT，
+ * 焦點在 `<g class="node">` 上不會被擋掉。同一行也會讓「點完之後 200ms 內按任何鍵」把平移
+ * 掐在半路。修法是把 `cancelCenterPan()` 移進「真的是平移／縮放按鍵」那個分支。
+ */
+test('N5. 鍵盤 Enter 開節點也會置中，途中按其他鍵不會把平移掐掉', async ({ page, isMobile }) => {
+  test.skip(isMobile, '僅桌機：手機版不做置中平移');
+  await page.goto('/tree');
+  await page.waitForSelector('#tree g.node');
+
+  await page.locator('g.node[data-id="4112"]').focus();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#detail')).toBeVisible();
+  await expect.poll(() => centerOffset(page, '4112'),
+    { message: 'Enter 開節點也要把鏡頭帶到畫面中央' }).toBeLessThanOrEqual(2);
+
+  // 第二半：點開之後立刻按一個不管平移的鍵（'a' 兩邊的 handler 都不處理），平移要照樣走完。
+  await page.goto('/tree');
+  await page.waitForSelector('#tree g.node');
+  await page.locator('g.node[data-id="5113"]').click();
+  await page.keyboard.press('a');
+  await expect.poll(() => centerOffset(page, '5113'),
+    { message: '平移途中按無關的鍵不該把它掐掉' }).toBeLessThanOrEqual(2);
+});
+
+/**
+ * N6. 選好節點之後在搜尋框打字，卡片會多一行——但不可以因此壓到它正在描述的那顆節點。
+ *
+ * 2026-08-23 code review 抓到：篩選一變，`applyFilter()` → `select()` 重畫卡片，多出
+ * 「含 N 個被篩選隱藏的前置」一行（實測 279.7 → 312.2）。這條路徑**刻意不重新置中**
+ * （不然每打一個字鏡頭就飛一次），而當時的高度上限是用整個視窗算的，於是卡片一長高就被
+ * 下面的夾制推到節點身上——四顆抽樣節點有三顆被完全蓋住（重疊 467.6 px²）。
+ * 修法有兩半：高度上限改用「卡片那一側到畫面邊緣還剩多少」算，以及置中時多留一行的餘裕
+ * （CENTER_SLACK），讓這種長高吸收得掉、不必冒出捲軸。
+ */
+test('N6. 打字改篩選之後，卡片不壓到節點、也不跳到另一邊', async ({ page, isMobile }) => {
+  test.skip(isMobile, '僅桌機：手機版卡片是底部抽屜，本來就不疊在節點上');
+  for (const id of ['2113', '4112', '2304', '5113']) {
+    await page.goto(`/tree?node=${id}`);
+    await expect(page.locator('#detail')).toBeVisible();
+    await expect.poll(() => centerOffset(page, id)).toBeLessThanOrEqual(2);
+
+    const before = await nodeOverlap(page, id);
+    expect(before.overlap, `${id} 打字前就不該重疊`).toBe(0);
+
+    await page.locator('#search').fill('骰');
+    await expect.poll(async () => (await nodeOverlap(page, id)).overlap,
+      { message: `${id} 打字之後卡片不可以壓到節點` }).toBe(0);
+
+    const after = await nodeOverlap(page, id);
+    // 前提斷言：卡片**真的**長高了。少了它，「沒重疊」也可能是因為根本沒發生重排。
+    expect(after.height, `${id} 篩選那一行應該讓卡片變高`).toBeGreaterThan(before.height);
+    // 擺法不准跟著打字跳邊：sideLeastCovered() 模擬的是「置中之後」的版面，而這條路徑
+    // 不會置中，重算只會算出一個不存在的版面。
+    expect(after.side, `${id} 擺法不該因為打字而換邊`).toBe(before.side);
+  }
+
+  // 第二半：使用者把節點往上拖，卡片那一側的空間縮到「比整張卡片矮、但還不到換邊門檻」時，
+  // 卡片必須自己變矮（內部捲動），不可以被夾制推到節點身上。
+  // ⚠️ 這一段是獨立的：上面那組打字的成長量（+32.5px）已經被 CENTER_SLACK 吸收掉，
+  // 所以把高度上限改回「整個視窗」算，上面那組仍然全綠（實測過）。這裡才真的打到那條路。
+  await page.goto('/tree?node=4112');
+  await expect(page.locator('#detail')).toBeVisible();
+  await expect.poll(() => centerOffset(page, '4112')).toBeLessThanOrEqual(2);
+
+  const natural = (await nodeOverlap(page, '4112')).height;
+  const room = () => page.evaluate(() => {
+    const n = document.querySelector('g.node[data-id="4112"] .icon')!.getBoundingClientRect();
+    const tb = document.getElementById('toolbar')!.getBoundingClientRect();
+    return n.top - tb.bottom - 24; // 24 = 上下各一個 GAP
+  });
+  // 目標留白 240：介於 MIN_PANEL_H（200，低於它就換邊）與卡片自然高度（約 280）之間，
+  // 正好是「不換邊但整張放不下」那條縫。
+  const dy = Math.round(await room() - 240);
+  expect(dy, '前提：一開始那一側的空間要比目標大，才有得拖').toBeGreaterThan(20);
+  await page.mouse.move(200, 600);
+  await page.mouse.down();
+  for (let i = 1; i <= 10; i++) await page.mouse.move(200, 600 - (dy * i) / 10);
+  await page.mouse.up();
+  await expect.poll(async () => Math.round(await room()),
+    { message: '前提：畫布真的被拖上去了' }).toBeLessThanOrEqual(245);
+
+  const dragged = await nodeOverlap(page, '4112');
+  expect(dragged.overlap, '空間變小時卡片要自己變矮，不可以壓到節點').toBe(0);
+  expect(dragged.height, '卡片應該被那一側的空間裁短').toBeLessThan(natural);
 });
 
 /**
@@ -1381,12 +1691,14 @@ test('Z2. 詞彙頁的「搜尋 #X」才會真的搜尋，而且會退回節點�
   expect(new URL(page.url()).searchParams.get('q')).toBe('破滅');
 });
 
-test('Z4. 卡片換頁的過渡：高度單調、垂直中心不漂、不反向', async ({ page }) => {
+test('Z4. 卡片換頁的過渡：高度單調、貼著節點的那一緣不漂、不反向', async ({ page }) => {
   // 換頁時卡片會抖（2026-08-20 人工回報）。四個獨立原因，全部是量錯東西：
   //   1. 量起始高度時新視圖還在正常流程 → `.stack` 是兩張加起來，先暴衝到 565px 再縮回。
   //   2. `.animating` 才加 `overflow: hidden` → 建立 BFC 改變邊界外距收合，class 一掛上
   //      高度就自己跳 12.4px，觸發一次多餘的 transition，真正的動畫開始前先抖一下。
   //   3. 只動 height 不動 top → 卡片是「往上收」不是「上下往中間收」。
+  //      ⚠️ 2026-08-23 卡片改成擺在節點上方／下方之後，這一條要守的東西換了：現在該固定不動
+  //      的是**貼著節點的那一緣**（放上方＝下緣、放下方＝上緣），不是垂直中心。
   //   4. 把 `.stack` 的高度餵給 positionPanel（它要的是**整張卡片**的高度，多一層 padding）
   //      → top 算偏一半，動畫途中卡片往下漂 16.9px。
   //
@@ -1395,12 +1707,15 @@ test('Z4. 卡片換頁的過渡：高度單調、垂直中心不漂、不反向'
   async function trace(click: () => Promise<void>) {
     await page.evaluate(() => {
       const el = document.getElementById('detail')!;
-      const w = window as unknown as { __s: { top: number; h: number; c: number }[] };
+      const w = window as unknown as { __s: { top: number; b: number; h: number; c: number }[] };
       w.__s = [];
       const t0 = performance.now();
       const tick = () => {
         const r = el.getBoundingClientRect();
-        w.__s.push({ top: +r.top.toFixed(1), h: +r.height.toFixed(1), c: +(r.top + r.height / 2).toFixed(1) });
+        w.__s.push({
+          top: +r.top.toFixed(1), b: +r.bottom.toFixed(1),
+          h: +r.height.toFixed(1), c: +(r.top + r.height / 2).toFixed(1),
+        });
         if (performance.now() - t0 < 900) requestAnimationFrame(tick);
       };
       requestAnimationFrame(tick);
@@ -1408,7 +1723,7 @@ test('Z4. 卡片換頁的過渡：高度單調、垂直中心不漂、不反向'
     await click();
     await page.waitForTimeout(1000);
     const samples = await page.evaluate(() =>
-      (window as unknown as { __s: { top: number; h: number; c: number }[] }).__s);
+      (window as unknown as { __s: { top: number; b: number; h: number; c: number }[] }).__s);
     expect(samples.length).toBeGreaterThan(20);   // rAF 取樣真的有跑
     return samples;
   }
@@ -1452,14 +1767,24 @@ test('Z4. 卡片換頁的過渡：高度單調、垂直中心不漂、不反向'
   assertSmoothHeight(pop);
   assertNoCenterReversal(pop);
 
-  // (B) 沒有被夾制時（節點在畫面中段、視窗夠高）：垂直中心必須**完全不動**，
-  //     也就是「上下往中間收」。這才是原因 3 與 4 真正的守門條件——(A) 那組被夾制，
-  //     中心本來就會移動，量不出那兩個 bug。
+  // (B) 沒有被夾制時（節點在畫面中段、視窗夠高）：**貼著節點的那一緣**必須完全不動。
+  //     這才是原因 3 與 4 真正的守門條件——(A) 那組被夾制，那一緣本來就會移動，量不出
+  //     那兩個 bug。
+  //     ⚠️ 方向鍵平移會中止置中平移（那是刻意的：使用者一動畫布就該讓位），所以這裡按完
+  //     ArrowUp 之後卡片跟節點的相對位置就固定了，量到的不是動畫半路的值。
   await page.setViewportSize({ width: 1400, height: 1000 });
   await page.goto('/tree?node=5004');
+  await expect(page.locator('#detail')).toBeVisible();
   await page.locator('#tree').focus();
   for (let i = 0; i < 3; i++) await page.keyboard.press('ArrowUp');
   await page.waitForTimeout(200);
+
+  // 卡片擺上面還是下面是算出來的（tree-canvas.ts 的 sideLeastCovered()），測試不猜、當場問。
+  const above = await page.evaluate(() => {
+    const p = document.getElementById('detail')!.getBoundingClientRect();
+    const n = document.querySelector('g.node[data-id="5004"] .icon')!.getBoundingClientRect();
+    return p.bottom <= n.top + 1;
+  });
 
   for (const act of [
     async () => { await top().locator('.kw').first().click(); },
@@ -1467,10 +1792,12 @@ test('Z4. 卡片換頁的過渡：高度單調、垂直中心不漂、不反向'
   ]) {
     const s = await trace(act);
     assertSmoothHeight(s);
-    const cs = s.map(x => x.c);
-    expect(Math.max(...cs) - Math.min(...cs)).toBeLessThanOrEqual(1);
-    // 而且 top 真的有跟著動——不然「中心不動」也可能是因為高度根本沒變
-    expect(Math.abs(s[s.length - 1]!.top - s[0]!.top)).toBeGreaterThan(50);
+    const glued = s.map(x => (above ? x.b : x.top));
+    const free = s.map(x => (above ? x.top : x.b));
+    expect(Math.max(...glued) - Math.min(...glued),
+      `卡片貼著節點的那一緣（${above ? '下緣' : '上緣'}）不該動`).toBeLessThanOrEqual(1);
+    // 而且另一緣真的有跟著動——不然「那一緣不動」也可能是因為高度根本沒變
+    expect(Math.abs(free[free.length - 1]! - free[0]!)).toBeGreaterThan(50);
   }
 });
 


### PR DESCRIPTION
桌機點開骰子資訊時，卡片跟前置鏈都落在節點右邊，卡片把剛高亮起來的鏈整條蓋掉。

## 改了什麼

- **選節點時把節點緩動平移到畫面水平中央**（約 200ms，`prefers-reduced-motion` 直接跳），卡片改成貼在節點**上方或下方**，不再左右擺放。擺哪一邊是**算出來的**（`sideLeastCovered()` 實際模擬兩種擺法各會蓋住幾個前置節點，取少的）——五個分支生長方向不同，1 系往上、2／3 系往下、4 系往左、5 系往右，寫死任何一邊都會有兩系全毀。
- **卡片改成橫式兩欄**：左欄「這個節點是什麼」、右欄「要花多少才走得到」，最長的重置警告跨兩欄放底部。寬 32rem、內距與字級各降一級。手機維持全寬單欄抽屜，尺寸不動。
- 置中平移期間**卡片一次到位、只有畫布在走**（先前是卡片整段不動、最後一幀瞬移）。

## 實測（1440×900，全站 239 顆節點）

| | 前置鏈被蓋的節點 | 被蓋節點總數 | 單顆最慘 |
|---|---|---|---|
| 改版前 | 152 | 749 | 14/15 |
| 只固定放上方 | 155 | — | 13/14 |
| 本 PR | 47 | 87 | 6/14 |

剩下那 47 顆是扇形展開、前置鏈在節點上下都有，沒有任何一側避得開。

## 修掉的四個缺陷

1. `window` 的 keydown handler 在檢查按鍵之前就無條件中止置中平移 → 節點上按 Enter 完全不會置中（節點停在 x=172 而不是 640），點擊後 200ms 內按任何鍵也會把平移掐在半路。
2. 選好節點後在搜尋框打字，卡片多一行（279.7→312.2）而該路徑不重新置中，夾制把卡片推到節點身上（四顆抽樣三顆被完全蓋住）。高度上限改用「卡片那一側剩多少空間」算，置中時多留一行餘裕。
3. `select()` 每次 input 事件都重做兩次強制版面計算 ＋ 一次前置鏈模擬，而且模擬的是「置中之後」的版面、篩選路徑根本不會置中。
4. `schedulePositionPanel()` 的 `cancelAnimationFrame` ＋ 重排會被「每幀都寫 transform」的來源餓死；換頁動畫終點用 `offsetHeight`（四捨五入成整數）量，280 vs 實際 279.7 會讓卡片在最後一格越過落定位置。

## 測試

新增 N2（不蓋前置鏈）、N3（平移期間卡片不動＋重新定位不被餓死）、N4（橫式兩欄／手機單欄）、N5（Enter 置中）、N6（打字與拖曳都不壓到節點）；N／V／Z4 跟著改斷言方向。每一條都跑過會紅的反例。

`npm test` 473 passed、`npm run e2e` 252 passed / 0 failed、`typecheck` 與 `validate` 全綠。`tree.json` sha256 不變（`a567d32e…`）。
