### PR TITLE
元件質感補上高光與凹陷，圓角收小一階

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
 
 ## 設計系統
 
-`:root` 有五組 token，全部定義在 **`src/styles/tokens.css`**，**新增樣式一律用它們**：
+`:root` 有六組 token，全部定義在 **`src/styles/tokens.css`**，**新增樣式一律用它們**：
 ⚠️ **token 定義只准留在 `tokens.css`，不要寫到別的檔**——`tests/styles/tokens.test.ts`「每個
 `var(--x)` 都真的定義得出來」那條拿 `tokens.css` 當唯一來源，正則是 `^\s{2}(--…)`（只認縮排
 兩格、不綁 `:root` 區塊，故意不合併九個檔一起掃），寫到別處會讓那條檢查對那個 token 失效。
@@ -308,14 +308,22 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
 | 組 | token | 說明 |
 |---|---|---|
 | 間距 | `--space-h/1..7` | 4px 網格（`--space-h` 是唯一半階 2px） |
-| 圓角 | `--r-xs/sm/md/lg/pill` | 4/6/10/14/999px |
+| 圓角 | `--r-xs/sm/md/lg/pill` | 3/4/5/7/999px（2026-08-26 整體收小一階） |
 | 字級 | `--fs-xs/sm/md/base/lg/xl/2xl/3xl` | `--fs-base` 是 1rem |
 | 表面 | `--surface-1/2/3`、`--border-strong` | 見下 |
 | 陰影與節奏 | `--shadow-1/2/3`、`--t-fast/med`、`--ring` | `--shadow-3` 給浮在畫布上的東西 |
+| 面的質感 | `--hair`、`--face`／`--face-lift`／`--face-float`、`--p-lift` | 見下 |
 
 - **表面分層**：靜態頁的面 → `--surface-1`；浮在畫布上的 chrome（`#toolbar`、`#detail`、
   `#branch-chips`、下拉選單、`/dice` 的篩選列）→ `--surface-2`；hover／選中的填色 → `--surface-3`。
   舊的 `--panel` 已刪除——一個東西兩個名字正是要收掉的漂移來源。
+- **面的質感用 `--face-*`，不要在元件裡自己疊 box-shadow**（2026-08-26 PR ④）。三個是同一個
+  配方的三個狀態：`--face` 靜止（上緣 `--hair` 高光 ＋ 下緣硬邊 ＋ `--shadow-2`）、`--face-lift`
+  hover（硬邊跟著 `--p-lift` 長）、`--face-float` 浮在畫布上的面（**不要下緣硬邊**——硬邊在講
+  「它坐在某個平面上」，而 `#detail`／下拉選單沒有坐在任何東西上）。抄散到元件檔就是四份會漂
+  的複本，跟 `--panel`、`render.ts` 的第二份金色同一族。
+- **hover 抬升一律 `var(--p-lift)`**，不要再寫死 `translateY(-2px)`：`--face-lift` 的下緣硬邊
+  是用 `calc(2px + var(--p-lift))` 跟著它算的，寫死就對不上。
 - **焦點框全站只有一條** `:focus-visible { outline: var(--ring) }`。元件只在需要**額外**回饋時才補。
 - **動畫長度一律用 `cssMs()` 從 CSS 讀**，JS 不寫第二份。
 - **減少動態的規則每個檔自帶一份**（`chrome.css`／`components.css`／`dice.css`／`detail.css`
@@ -324,11 +332,18 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
   過場）與 `#filters-toggle`（三條）各一個），刻意不寫成
   `*{transition-duration:0.01ms!important}`：那會連 opacity 一起關掉，而 `/tree` 的篩選淡出是靠
   opacity 在**傳達資訊**，不是裝飾。
+  ⚠️ **`tokens.css` 也有一個 reduce 區塊，而且它是唯一一個改 token 而不是改元件的**：
+  重新宣告 `--face-lift`，把下緣硬邊從 `calc(2px + var(--p-lift))` 壓回 2px。理由與「為什麼
+  不能在元件的 reduce 區塊裡覆寫 `--p-lift`」寫在該處——**自訂屬性的 `var()` 代換是在宣告
+  它的那個元素上算完再繼承的**，在子元素上改來源變數影響不到已經算完的那一份。
 - ⚠️ **`:has()` 與 `color-mix()` 都要有退化路徑。** 切換鈕的「選中」完全靠 `:has(input:checked)`
   ＋底色而真正的 checkbox 是 `opacity: 0`——不支援 `:has()` 的引擎或 `forced-colors: active` 下，
   五顆鈕長得一模一樣、焦點也看不見。`color-mix()` 一律在前面補一行純色 fallback。
 - **守門**：`tests/styles/tokens.test.ts` 掃裸的 px／rem（例外寫在檔案裡的 `ALLOWED` 並附理由），
-  並確認每個 `var(--x)` 都在 `:root` 定義得出來（打錯的名字不會報錯，只會安靜掉回預設值）。
+  確認每個 `var(--x)` 都在 `:root` 定義得出來（打錯的名字不會報錯，只會安靜掉回預設值），
+  並確認**級距內沒有兩個 token 撞值**（`--r-*`／`--fs-*`／`--space-*`／`--shadow-*`）——
+  同一個值兩個名字時改哪一個都只有一半的地方會跟上，2026-08-26 收小圓角時 `--r-sm` 差點
+  撞上 `--r-xs`。
   ⚠️ **掃描名單全部自動列舉**（2026-08-26 拆檔後）：`.css` 用 `readdirSync(src/styles)`；
   `.astro` 用 `readdirSync({ recursive: true })` 掃 `src/pages`（含 `guide/` 子目錄）與
   `src/components`，挑出內容含 `<style` 的檔案，不是寫死幾個檔名。並自帶一條**反例斷言**：
@@ -344,7 +359,7 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
 
 | 檔 | 放什麼 | 誰載 |
 |---|---|---|
-| `tokens.css` | `:root` 的五組 token（間距／圓角／字級／表面／陰影與節奏）——**唯一**允許定義 token 的地方 | Base |
+| `tokens.css` | `:root` 的六組 token（間距／圓角／字級／表面／陰影與節奏／面的質感）——**唯一**允許定義 token 的地方 | Base |
 | `base.css` | 全站重置（`*`／`html`／`body`／`main`／`footer`／`a`／`pre`）＋ `.sr-only` | Base |
 | `chrome.css` | 全站導覽列 `#site-nav`（含「遊戲介紹」下拉） | Base |
 | `content.css` | 靜態內容頁共用 `.page`（首頁／圖鑑／遊戲介紹）＋首頁訪客計數器 `#hit-counter`＋詞彙頁 `.kw-*` | Base |

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -23,7 +23,12 @@
   background: color-mix(in srgb, var(--surface-2) 88%, transparent);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
+  /* 底線走 --gold 35%，不是 --border：導覽列是全站唯一一條橫貫畫面的線，用中性邊框色
+     時它只是「內容到這裡為止」，換成暗金之後它才是站台自己的一條邊。35% 是上限——
+     再高就會跟 .brand 與 [aria-current] 的金色搶，那兩個才是要被讀到的東西。
+     前一行是 fallback，理由同上面 background 那一對。 */
   border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid color-mix(in srgb, var(--gold) 35%, transparent);
 }
 
 /* 導覽列的連結預設不是金色。全部都金色的時候「你在哪一頁」就沒有地方講了——金色留給
@@ -158,7 +163,8 @@
   background: var(--surface-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-3);
+  /* 跟 #detail 同一種東西（浮在內容上的面），用同一個配方。 */
+  box-shadow: var(--face-float);
 }
 #site-nav .nav-menu-items a {
   padding: var(--space-2) var(--space-3);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -11,7 +11,7 @@
   background: var(--surface-1);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--face);
   color: var(--fg);
   text-decoration: none;
   transition:
@@ -22,8 +22,8 @@
 :is(.home-card, .guide-card):hover,
 :is(.home-card, .guide-card):focus-visible {
   border-color: var(--gold);
-  box-shadow: var(--shadow-2);
-  transform: translateY(-2px);
+  box-shadow: var(--face-lift);
+  transform: translateY(calc(-1 * var(--p-lift)));
   text-decoration: none;
 }
 .home-card h2 {
@@ -123,6 +123,7 @@
   transition:
     color var(--t-fast) ease,
     background-color var(--t-fast) ease,
+    box-shadow var(--t-fast) ease,
     border-color var(--t-fast) ease;
 }
 .chip input {
@@ -147,6 +148,11 @@
   background: var(--surface-3);
   background: color-mix(in srgb, var(--branch, var(--gold)) 18%, var(--surface-1));
   color: var(--fg);
+  /* 內發光：底色只混 18%（見上），單靠它在五顆同時亮起時分不出誰開著。光暈往內收，
+     邊框那一圈才是被強調的東西——往外發光的話它會跟隔壁那顆的光暈糊在一起。
+     前一行同樣是 color-mix 的 fallback：不支援的引擎退回一層中性內陰影，不會變成沒有。 */
+  box-shadow: inset 0 0 11px rgb(255 255 255 / 6%);
+  box-shadow: inset 0 0 11px color-mix(in srgb, var(--branch, var(--gold)) 22%, transparent);
 }
 /* 焦點框畫在整顆鈕上。checkbox 自己是透明的，:focus-visible 落在它身上時看不到任何東西。 */
 .chip:has(input:focus-visible),
@@ -210,12 +216,11 @@
   }
 }
 
-/* 卡片左緣的分支色條（2026-08-22）。五系色本來只活在 /tree 的畫布裡，圖鑑上 41 張卡片
-   長得一模一樣，要靠讀文字才知道是哪一系。
-   用 border-left 而不是 ::before：`.card-term` 是 `inset: 0` 的絕對定位覆蓋層，它的定位
-   基準是卡片的**內距框**，會蓋掉任何畫在內距框裡的東西——色條畫成邊框才留得住。
-   （同理，左邊框從 1px 變 3px 會讓內距框整體右移 2px，但本文與覆蓋層是一起移的，
-   兩者不會錯位，所以不需要補 padding。） */
+/* 卡片的分支色（2026-08-22 起，2026-08-26 改到頂緣）。五系色本來只活在 /tree 的畫布裡，
+   圖鑑上 41 張卡片長得一模一樣，要靠讀文字才知道是哪一系。
+   ⚠️ 現在畫在 `.dice-card::after`（頂緣 3px 漸層），**不是 border-left**——左緣那條
+   2026-08-26 拿掉了。`.card-term` 是 `inset: 0` 的絕對定位覆蓋層，會蓋掉任何畫在內距框裡
+   的東西，所以 `::after` 靠 `z-index: 2` 贏過它（見 dice.css 該處，E2E C12 守）。 */
 :is(.dice-card, .chip)[data-branch='nature'] { --branch: var(--nature); }
 :is(.dice-card, .chip)[data-branch='engineering'] { --branch: var(--engineering); }
 :is(.dice-card, .chip)[data-branch='magic'] { --branch: var(--magic); }

--- a/src/styles/detail.css
+++ b/src/styles/detail.css
@@ -28,7 +28,8 @@
   font-size: var(--fs-md);
   border: 1px solid var(--border-strong);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-3);
+  /* --face-float 而不是 --face：面板浮在畫布上，沒有坐在任何平面上，下緣硬邊會說謊。 */
+  box-shadow: var(--face-float);
 }
 #detail h2 {
   margin-top: 0;

--- a/src/styles/dice.css
+++ b/src/styles/dice.css
@@ -50,19 +50,34 @@
   padding: var(--space-3);
   background: var(--surface-1);
   border: 1px solid var(--border);
-  /* fallback 走 --border：資料若冒出第六個分支，卡片會退回一般邊框，不會變成透明或黑色。 */
-  border-left: 3px solid var(--branch, var(--border));
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--face);
   transition:
     border-color var(--t-fast) ease,
     box-shadow var(--t-fast) ease,
     transform var(--t-fast) ease;
 }
+/* 頂緣 3px 的屬性色漸層——這是卡片上**唯一**的分支色（Yuki 2026-08-26 拍板拿掉左緣色條，
+   兩條同色的線圍成「⌐」太吵，留上面那條就夠）。
+   fallback 走 --gold：資料若冒出第六個分支，`--branch` 解不出來，這條線會是金色而不是
+   消失或變黑。
+   ⚠️ z-index 要 2：`.card-term`（關鍵字就地視圖）是 `inset:0; z-index:1` 的覆蓋層，
+   不給 2 的話翻到關鍵字頁時這條線會被蓋掉，看起來像卡片換了一張。
+   ⚠️ pointer-events: none：它橫跨整張卡片的頂緣，會吃掉標題列的點擊。
+   `.dice-card` 本來就有 overflow: hidden（見上面的說明），圓角不會被這條線戳出去。 */
+.dice-card::after {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 2;
+  height: 3px;
+  pointer-events: none;
+  background: linear-gradient(90deg, var(--branch, var(--gold)), transparent 70%);
+}
 .dice-card:hover {
   border-color: var(--branch, var(--gold));
-  box-shadow: var(--shadow-2);
-  transform: translateY(-2px);
+  box-shadow: var(--face-lift);
+  transform: translateY(calc(-1 * var(--p-lift)));
 }
 .dice-card[hidden] {
   display: none; /* 篩選用；這裡要真的收掉版面，跟 /tree 的淡出是兩回事（那裡要保留位置） */
@@ -153,6 +168,10 @@
   background: var(--surface-0);
   border: 1px solid var(--border);
   border-radius: var(--r-pill);
+  /* 凹陷：pill 的底色只比卡片低一階（--surface-0 → --surface-1 對比 1.11），單靠色差
+     說不出「嵌進去」。上緣的內陰影補上那個資訊。方向跟 --face 的 --hair 正好相反，
+     兩者一起看才成立：卡片往前凸、pill 往後凹。 */
+  box-shadow: inset 0 1px 3px rgb(0 0 0 / 55%);
   /* 切檔時只有透明度會變。**尺寸不動這件事不是這裡守的**，是 .stat-v 的 inline-grid 疊放
      （見下面）——41 張卡片排在 CSS grid 裡，任何一顆 pill 變寬都可能多擠出一列而把同一列的
      鄰居一起撐高，同 /tree 工具列那條「會出現／消失的東西尺寸不准變」的教訓。 */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -59,11 +59,16 @@
   --space-6: 2rem;
   --space-7: 3rem;
 
-  /* 圓角：越大的面用越大的半徑，小徽章不要跟卡片同一個值。 */
-  --r-xs: 4px;
-  --r-sm: 6px;
-  --r-md: 10px;
-  --r-lg: 14px;
+  /* 圓角：越大的面用越大的半徑，小徽章不要跟卡片同一個值。
+     2026-08-26 整體收小一階（`6/10/14` → `4/5/7`）：舊值在深色底上把每一張卡片都圓成
+     一顆藥丸，元件之間分不出「面」與「徽章」。
+     ⚠️ `--r-xs` 跟著從 4px 降到 3px，理由不是視覺是**避免撞值**：`--r-sm` 收到 4px 之後
+     它會跟 `--r-xs` 一模一樣，變成同一個值兩個名字——那正是這個 repo 一路在收掉的漂移
+     來源（舊的 `--panel` 就是這樣拆掉的）。`--r-pill` 不動。 */
+  --r-xs: 3px;
+  --r-sm: 4px;
+  --r-md: 5px;
+  --r-lg: 7px;
   --r-pill: 999px;
 
   /* 字級：--fs-base 是 1rem，往下三階給輔助資訊、往上四階給標題。 */
@@ -96,9 +101,36 @@
   --shadow-2: 0 4px 14px rgb(0 0 0 / 35%);
   --shadow-3: 0 10px 30px rgb(0 0 0 / 50%);
 
+  /* 面的質感（2026-08-26）。--hair 是上緣那條 1px 高光——深色 UI 靠它讓一個面看起來是
+     「往前凸」而不是「一塊比較亮的底色」。
+     ⚠️ 三個 --face-* **必須收在這裡、不准在元件裡各抄一份**：它們是同一個配方的三個狀態，
+     抄散到 components/dice/detail 三個檔之後，改高光就得改三個地方而且不會有任何東西提醒
+     你漏了一個。這是這一輪一路在收的漂移類別（--panel、render.ts 的金色、board-export 的
+     fallback 都是同一族）。
+     疊放順序有意義：inset 高光在最上、下緣硬邊次之、外圈柔影在最外。 */
+  --hair: rgb(255 255 255 / 7%);
+  --face: inset 0 1px 0 var(--hair), 0 2px 0 rgb(0 0 0 / 35%), var(--shadow-2);
+  --face-lift: inset 0 1px 0 var(--hair), 0 calc(2px + var(--p-lift)) 0 rgb(0 0 0 / 35%), var(--shadow-3);
+  /* 浮在畫布上的面（詳情面板、下拉選單）不要下緣硬邊：硬邊在講「它坐在某個平面上」，
+     而這兩個東西沒有坐在任何東西上。
+     ⚠️ **這一輪只換了兩個**：`#detail`（detail.css）與 `#site-nav .nav-menu-items`
+     （chrome.css）。同一族但**還停在裸 --shadow-* 的**有四個，各自的值本來就不一致，
+     不是這張 PR 弄出來的：`#toolbar`（tree.astro，--shadow-2）、`/tree` 手機版篩選抽屜
+     （tree.astro，--shadow-3）、`/board` 的面板（board.css，--shadow-3）、`/dice` 的篩選列
+     （dice.css，--shadow-1）。**調 --face-float 的時候記得那四個不會跟著動**——要不要把
+     它們一起收進來是視覺決定，得先給 Yuki 看對照圖（2026-08-26 code review 提出）。 */
+  --face-float: inset 0 1px 0 var(--hair), var(--shadow-3);
+
   /* 微互動的節奏。跟 --slide-ms 是兩回事：那個是換頁，這兩個是 hover／焦點這種即時回饋。 */
   --t-fast: 120ms;
   --t-med: 200ms;
+
+  /* hover 抬升量。原本是三個檔各自寫死的 `translateY(-2px)`（.home-card／.guide-card／
+     .dice-card），收成 token 是為了讓 --face-lift 的下緣硬邊能跟著它一起長——卡片往上抬
+     2px、影子的硬邊就要往下多 2px，方向感才對得上。
+     ⚠️ E2E 有守：chrome.spec.ts 的「形狀二」會先斷言 hover 真的有 transform（正向控制），
+     再驗 reduce 之下被關掉。把這裡改成 0 會讓那條的正向控制紅。 */
+  --p-lift: 2px;
 
   /* 全站唯一的鍵盤焦點框，見底下的 :focus-visible 規則。 */
   --ring: 2px solid var(--gold);
@@ -106,4 +138,24 @@
 
   /* 字型只用系統堆疊，不自架字型檔（CJK 字型體積過大）。 */
   --font: 'Noto Sans TC', 'Microsoft JhengHei', sans-serif;
+}
+
+/* 減少動態：把 --face-lift 的下緣硬邊壓回跟 --face 同一階。
+ *
+ * 起因（2026-08-26 code review）：`components.css`／`dice.css` 的 reduce 區塊只關掉
+ * `transform`，硬邊仍然是 `calc(2px + var(--p-lift))` = 4px——卡片不動、影子卻往下掉 2px，
+ * 影子脫離了它應該在追的那個元素。
+ *
+ * ⚠️ **為什麼改在這裡而不是在元件的 reduce 區塊裡寫 `--p-lift: 0px`**：那樣沒有用，實測
+ * 過。自訂屬性的 `var()` 代換是在**宣告它的那個元素**上算完再往下繼承的——`--face-lift`
+ * 宣告在 `:root`，它的值早就把 `--p-lift: 2px` 烤進去了，之後在 `.home-card:hover` 上改
+ * `--p-lift` 影響不到已經算完的 `--face-lift`。要改就得改 `:root` 這一份。
+ *
+ * 好處是元件的 reduce 區塊一行都不用動，將來任何一個用 --face-lift 的地方都自動跟著平掉。
+ * 外圈柔影仍然升到 --shadow-3，所以 hover 的回饋不會整個消失。
+ * 守門：`tests/e2e/chrome.spec.ts` 的 D7b（reduce 之下硬邊不准比靜止時大）。 */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --face-lift: inset 0 1px 0 var(--hair), 0 2px 0 rgb(0 0 0 / 35%), var(--shadow-3);
+  }
 }

--- a/tests/e2e/chrome.spec.ts
+++ b/tests/e2e/chrome.spec.ts
@@ -75,17 +75,27 @@ test('D3. 目前分頁標 aria-current，而且沒有把下拉選單的 ▾ 箭�
   expect(pseudo.beforeBg).toBe(await resolveColor(page, '--gold'));
 });
 
-test('D4. 骰子卡左緣是所屬分支的顏色，五系各驗一張', async ({ page }) => {
+test('D4. 骰子卡頂緣是所屬分支的顏色，五系各驗一張', async ({ page }) => {
+  // 2026-08-26 之前這條量的是 `border-left`；分支色條那時改到頂緣的 `.dice-card::after`
+  // （Yuki 拍板拿掉左緣那條），所以這裡改量偽元素的漸層。
+  // ⚠️ 順便守「左緣不准再長回來」：兩條同色的線圍成「⌐」正是被拿掉的東西，只驗頂緣的話
+  // 有人把 border-left 加回去這條照樣綠。
   await page.goto('/dice');
   for (const branch of ['nature', 'engineering', 'magic', 'order', 'chaos']) {
     const card = page.locator(`.dice-card[data-branch="${branch}"]`).first();
     await expect(card, `${branch} 沒有任何骰子卡`).toHaveCount(1);
     const style = await card.evaluate(el => ({
-      color: getComputedStyle(el).borderLeftColor,
-      width: getComputedStyle(el).borderLeftWidth,
+      top: getComputedStyle(el, '::after').backgroundImage,
+      topH: getComputedStyle(el, '::after').height,
+      leftW: getComputedStyle(el).borderLeftWidth,
+      leftColor: getComputedStyle(el).borderLeftColor,
     }));
-    expect(style.color, `${branch} 的左緣不是分支色`).toBe(await resolveColor(page, `--${branch}`));
-    expect(style.width).toBe('3px');
+    const expected = await resolveColor(page, `--${branch}`);
+    expect(style.top, `${branch} 的頂緣色線不是分支色（讀到 ${style.top}）`).toContain(expected);
+    expect(style.topH, `${branch} 的頂緣色線沒有高度`).toBe('3px');
+    expect(style.leftW, '左緣的分支色條長回來了（2026-08-26 拿掉的）').toBe('1px');
+    expect(style.leftColor, '左緣的分支色條長回來了（2026-08-26 拿掉的）')
+      .toBe(await resolveColor(page, '--border'));
   }
 });
 
@@ -335,16 +345,36 @@ test('D14. 減少動態的規則拆到各檔之後沒有漏掉任何一條', asy
     await expect.soft(el, `${c.path} 上找不到 ${c.selector}`).toBeAttached();
     // 同上一個形狀的理由：找不到就跳過，不要讓 el.hover() 卡 30 秒把整個 test 中止掉。
     if (!(await el.count())) continue;
+    // --face-lift 的下緣硬邊：`calc(2px + var(--p-lift))`，hover 時該從 2px 長到 4px。
+    // ⚠️ 一定要等過場跑完再讀（--t-fast 是 120ms），否則讀到的是 2.33px 這種中間值。
+    const edge = (shadow: string) =>
+      shadow.match(/rgba?\([^)]*\)\s+0px\s+([\d.]+)px\s+0px\s+0px(?!\s+inset)/)?.[1];
+    const shadowOf = () => el.evaluate(n => getComputedStyle(n).boxShadow);
+    const restEdge = edge(await shadowOf());
+
     await el.hover();
     const normal = await el.evaluate(n => getComputedStyle(n).transform);
     // 正向控制：hover 之後真的有 transform，下面那條斷言才有意義。
     expect.soft(normal, `${c.selector}:hover 平常沒有 transform，這條斷言等於沒守`).not.toBe('none');
+    await page.waitForTimeout(200);
+    const hoverEdge = edge(await shadowOf());
+    // 正向控制：硬邊平常真的會跟著 hover 長大，下面那條斷言才有意義。
+    expect.soft(hoverEdge, `${c.selector}:hover 的下緣硬邊沒有跟著長大（都是 ${restEdge}px），`
+      + '下面那條 reduce 斷言等於沒守').not.toBe(restEdge);
 
     await page.emulateMedia({ reducedMotion: 'reduce' });
     await el.hover();
     const reduced = await el.evaluate(n => getComputedStyle(n).transform);
     expect.soft(reduced,
       `${c.path} 的 ${c.selector}:hover 在 reduce 之下 transform 沒有被關掉（讀到 ${reduced}）`).toBe('none');
+    // 2026-08-26 code review 追加：transform 關掉還不夠。硬邊沒一起壓平的話，卡片不動而
+    // 影子往下掉 2px——影子脫離了它應該在追的那個元素。修法在 tokens.css 的
+    // `@media (prefers-reduced-motion: reduce) :root` 重新宣告 --face-lift；**不能**寫在
+    // 元件的 reduce 區塊裡覆寫 --p-lift（自訂屬性在宣告它的元素上就代換完了，實測無效）。
+    await page.waitForTimeout(200);
+    expect.soft(edge(await shadowOf()),
+      `${c.path} 的 ${c.selector}:hover 在 reduce 之下下緣硬邊仍然跟著長大（靜止 ${restEdge}px），`
+      + '卡片不動而影子往下掉').toBe(restEdge);
   }
 
   // --- 形狀三：#detail 系列，合成探針量，不驅動真的換頁動畫 ---

--- a/tests/e2e/codex.spec.ts
+++ b/tests/e2e/codex.spec.ts
@@ -6,6 +6,7 @@
 // `request.get()` 而不是 `page.goto()`：後者拿到的是 JS 跑完之後的 DOM，驗不到這件事。
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'node:fs';
+import sharp from 'sharp';
 import { resolveColor } from './probe';
 
 const tree = JSON.parse(
@@ -416,4 +417,58 @@ test('C11. 沒有 JS 時檔位照樣切得動（整塊是純 CSS）', async ({ b
   await card.locator('.stat-modes input[value="lv15dice7"]').check();
   await expect(card.locator('.stat-pill').first()).toHaveText(/攻擊力\s*2850/, { useInnerText: true });
   await ctx.close();
+});
+
+test('C12. 卡片頂緣的分支色線：真的畫得出來，翻到關鍵字頁也不會被蓋掉', async ({ page }) => {
+  // 那條線是 `.dice-card::after`（PR ④）。偽元素在 DOM 裡沒有節點，`toBeVisible()` 之類
+  // 的斷言一條都用不上——只有量像素會說話。
+  //
+  // ⚠️ 第二段（翻到關鍵字頁之後再量一次）才是這條測試存在的理由：`.card-term` 是
+  // `inset: 0; z-index: 1` 的覆蓋層，::after 少了 `z-index: 2` 就會被它整條蓋掉。而那個
+  // 失效模式**只在翻頁之後**才看得到，卡片正面完全正常，其餘 11 條 /dice 測試一條都不會紅。
+  await page.goto('/dice');
+
+  // 挑一張「有 #關鍵字 可以翻頁」而且掛了分支的卡片，分支色從它自己的屬性讀，不要寫死。
+  const card = page.locator('.dice-card[data-branch]').filter({ has: page.locator('a.kw-link') }).first();
+  await card.scrollIntoViewIfNeeded();
+  const branch = await card.getAttribute('data-branch');
+  const [r0, g0, b0] = (await resolveColor(page, `--${branch}`))
+    .match(/\d+/g)!.slice(0, 3).map(Number) as [number, number, number];
+
+  const box = (await card.boundingBox())!;
+  // 取樣範圍只取左上角一小塊：漸層在 70% 處就透明了，右半邊本來就該是卡片底色。
+  // 高度 8 CSS px 蓋得住 1px 上邊框 ＋ 3px 色線，還留了餘裕給裝置像素的四捨五入。
+  //
+  // ⚠️ x 從 box.x + 12 起算，避開左上角的圓角與 1px 邊框。這個偏移原本是為了避開
+  // `border-left: 3px solid var(--branch)`（跟頂緣同色，從 box.x 起算會量到它，把 ::after
+  // 整條刪掉也照樣綠——反例沒紅才抓到）。那條左緣色線 2026-08-26 已經拿掉，偏移留著只是
+  // 避開圓角；**不要因為理由變了就把它改回 box.x**，圓角那幾格是卡片底色。
+  const clip = { x: box.x + 12, y: box.y, width: 48, height: 8 };
+  const near = async () => {
+    const { data, info } = await sharp(await page.screenshot({ clip })).raw()
+      .toBuffer({ resolveWithObject: true });
+    let best = 999;
+    for (let i = 0; i < data.length; i += info.channels) {
+      const d = Math.abs(data[i]! - r0) + Math.abs(data[i + 1]! - g0) + Math.abs(data[i + 2]! - b0);
+      if (d < best) best = d;
+    }
+    return best;
+  };
+
+  // 正向控制：沒有這一段，下面那條在「根本沒畫那條線」時也會綠（兩次都找不到，但只斷言
+  // 第二次的話就看不出差別）。門檻 40 是三個通道的曼哈頓距離，容得下反鋸齒與漸層起點的
+  // 一點點混色，但容不下「整條線不存在」（那裡會是 --surface-1，距離 200 以上）。
+  const before = await near();
+  expect(before, `卡片正面就找不到 --${branch} 的頂緣色線，這條測試等於沒守`).toBeLessThan(40);
+
+  // 翻到 #關鍵字 的就地視圖，等過場停下來再量。
+  await card.locator('a.kw-link').first().click();
+  await expect(card.locator('.card-term-view[data-active]')).toBeVisible();
+  await page.waitForTimeout(400); // --slide-ms 是 280ms
+  const after = await near();
+  expect(after, `翻到關鍵字頁之後頂緣色線被 .card-term 蓋掉了（::after 的 z-index 沒贏）`)
+    .toBeLessThan(40);
+
+  // 它橫跨整張卡片的頂緣，不能吃掉底下的點擊。
+  expect(await card.evaluate(el => getComputedStyle(el, '::after').pointerEvents)).toBe('none');
 });

--- a/tests/styles/tokens.test.ts
+++ b/tests/styles/tokens.test.ts
@@ -130,7 +130,7 @@ describe('版面級距', () => {
     // ⚠️ 只讀 tokens.css，不要把九個檔合併起來當來源。下面那條正則是 `^\s{2}(--…):`，
     // 只認縮排兩格、不綁 :root 區塊——合併之後任何元件規則裡縮排兩格的自訂屬性
     // 都會被誤認成「:root 有定義」，這條規則就廢了。
-    const tokens = readFileSync(TOKENS_FILE, 'utf8');
+    const tokens = stripComments(readFileSync(TOKENS_FILE, 'utf8'));
     const defined = new Set([...tokens.matchAll(/^\s{2}(--[a-z0-9-]+):/gm)].map(m => m[1]!));
 
     // 不在 :root、由執行期寫入或由元件自己設的變數，各自的來源寫在旁邊。
@@ -149,6 +149,43 @@ describe('版面級距', () => {
       }
     }
     expect([...missing].sort()).toEqual([]);
+  });
+
+  /**
+   * 同一個級距裡不准有兩個 token 撞值。
+   *
+   * 起因：PR ④ 把 `--r-sm` 從 6px 收到 4px，而 `--r-xs` 本來就是 4px——兩個名字一個值。
+   * 那不是排版問題是**漂移來源**：之後有人要調「小徽章的圓角」時，兩個名字看起來都對，
+   * 改哪一個都會有一半的地方沒跟上，而且沒有任何東西會說話。這個 repo 已經為了同一件事
+   * 收掉過 `--panel`（一個面兩個名字）、`render.ts` 的第二份金色、`board-export.ts` 的
+   * 六條 fallback。
+   *
+   * 只掃「級距」——一串刻意排成階梯的 token。顏色不在名單裡：`--surface-0` 跟 `--bg`
+   * 將來真的可能刻意同值（見 tokens.css 裡 --surface-0 的說明）。
+   */
+  it('級距內不准有兩個 token 撞值', () => {
+    // ⚠️ 一定要先 stripComments：底下的正則只認「縮排兩格的 --name:」，而這個檔的註解
+    // 經常引用 token 名與舊值（`--r-sm` 收小那段就是），縮排剛好兩格的那一行會被當成
+    // 一筆定義，變成永遠修不好的假紅。同檔上面那條掃裸數值的測試早就這麼做了。
+    // （2026-08-26 code review 抓到；同一個檔的另外兩處讀 tokens.css 也一併補上。）
+    const tokens = stripComments(readFileSync(TOKENS_FILE, 'utf8'));
+    const defined = [...tokens.matchAll(/^\s{2}(--[a-z0-9-]+):\s*([^;]+);/gm)]
+      .map(m => ({ name: m[1]!, value: m[2]!.trim() }));
+
+    const LADDERS = ['--r-', '--fs-', '--space-', '--shadow-'];
+    const dupes: string[] = [];
+    for (const prefix of LADDERS) {
+      const group = defined.filter(t => t.name.startsWith(prefix));
+      // 正向控制：級距不存在（改名／打錯前綴）時這條會紅，而不是安靜地掃了 0 個 token。
+      expect(group.length, `級距 ${prefix}* 一個 token 都沒掃到——前綴過期了`).toBeGreaterThan(2);
+      const seen = new Map<string, string>();
+      for (const { name, value } of group) {
+        const prev = seen.get(value);
+        if (prev) dupes.push(`${prefix}*: ${prev} 與 ${name} 同為 ${value}`);
+        else seen.set(value, name);
+      }
+    }
+    expect(dupes).toEqual([]);
   });
 });
 
@@ -212,7 +249,7 @@ describe('import 順序＝層疊順序', () => {
  */
 describe('board-export 的色票 fallback', () => {
   it('六條 fallback 跟 tokens.css 的值一字不差', () => {
-    const tokens = readFileSync(TOKENS_FILE, 'utf8');
+    const tokens = stripComments(readFileSync(TOKENS_FILE, 'utf8'));
     // 只認縮排兩格的自訂屬性宣告，跟上面那條 var() 解析測試同一套規則。
     const defined = new Map(
       [...tokens.matchAll(/^\s{2}(--[a-z0-9-]+):\s*([^;]+);/gm)].map(m => [m[1]!, m[2]!.trim()]),


### PR DESCRIPTION
視覺翻新的第四張（PR ④）。圓角 `6/10/14 → 4/5/7`，並補上六個質感手法。

## 改了什麼

- **圓角收小**：`--r-sm/md/lg` 從 `6/10/14` 收到 `4/5/7`。`--r-xs` 跟著 4→3px——不是視覺理由，是 `--r-sm` 收到 4px 之後會跟它撞值，同一個值兩個名字正是這個 repo 一路在收的漂移來源。
- **新增三組 token**（都在 `tokens.css`）：`--hair` 上緣高光、`--face`／`--face-lift`／`--face-float` 三個狀態的面配方、`--p-lift` hover 抬升量（原本三個檔各自寫死 `translateY(-2px)`）。
- **六個手法**：卡片／面板上緣高光＋下緣硬邊、`.dice-card::after` 頂緣分支色漸層、chip 選中的內發光、`.stat-pill` 凹陷、`#site-nav` 底部金色細線、hover 陰影的硬邊跟著 `--p-lift` 長大。
- **骰子卡左緣的分支色條拿掉**，分支色只留頂緣那條。

## 新的守門

- `tokens.test.ts`：級距內（`--r-*`／`--fs-*`／`--space-*`／`--shadow-*`）不准有兩個 token 撞值。
- E2E `C12`：`.dice-card::after` 的分支色線量像素——包含「翻到 `#關鍵字` 就地視圖之後仍然看得見」（`.card-term` 是 `inset:0; z-index:1` 的覆蓋層，`::after` 沒給 `z-index: 2` 會被整條蓋掉，而卡片正面完全正常）。
- E2E `D4`：原本量 `borderLeftColor`，改量 `::after` 的漸層，並同時斷言左緣沒有長回來。
- E2E `D14`：reduce 之下不只 `transform` 要關掉，`--face-lift` 的下緣硬邊也不准跟著長大。

每一條都跑過反例確認會紅。

## 本地驗證

`npm run validate` ✅ ／ `typecheck` ✅ ／ `test` 611 passed ／ `e2e` 319 passed, 21 skipped