### PR TITLE
feat: 動效系統上線，補上按壓回饋與卡片進場

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
 
 ## 設計系統
 
-`:root` 有七組 token，全部定義在 **`src/styles/tokens.css`**，**新增樣式一律用它們**：
+`:root` 有八組 token，全部定義在 **`src/styles/tokens.css`**，**新增樣式一律用它們**：
 ⚠️ **token 定義只准留在 `tokens.css`，不要寫到別的檔**——`tests/styles/tokens.test.ts`「每個
 `var(--x)` 都真的定義得出來」那條拿 `tokens.css` 當唯一來源，正則是 `^\s{2}(--…)`（只認縮排
 兩格、不綁 `:root` 區塊，故意不合併九個檔一起掃），寫到別處會讓那條檢查對那個 token 失效。
@@ -311,7 +311,8 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
 | 圓角 | `--r-xs/sm/md/lg/pill` | 3/4/5/7/999px（2026-08-26 整體收小一階） |
 | 字級 | `--fs-xs/sm/md/base/lg/xl/2xl/3xl` | 0.75→2.4rem（2026-08-26 拉開對比，見下） |
 | 表面 | `--surface-1/2/3`、`--border-strong` | 見下 |
-| 陰影與節奏 | `--shadow-1/2/3`、`--t-fast/med`、`--ring` | `--shadow-3` 給浮在畫布上的東西 |
+| 陰影 | `--shadow-1/2/3`、`--ring` | `--shadow-3` 給浮在畫布上的東西 |
+| 動效 | `--t-fast/press/med/slow`、`--e-out/in-out/spring`、`--p-lift/press/stagger/stagger-max/glow` | 見下 |
 | 面的質感 | `--hair`、`--face`／`--face-lift`／`--face-float`、`--p-lift` | 見下 |
 | 排印 | `--font`、`--font-num`、`--ls-label` | 見下 |
 
@@ -350,13 +351,42 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
   `.stat-pill .stat-k`）。⚠️ 不要往內文或 1rem 的整句中文擴——中文加字距會把行內的詞界抹平，
   整行變成等距字塊（`#detail .meta` 因此刻意只掛 `--font-num`、不掛字距）。
 - **焦點框全站只有一條** `:focus-visible { outline: var(--ring) }`。元件只在需要**額外**回饋時才補。
-- **動畫長度一律用 `cssMs()` 從 CSS 讀**，JS 不寫第二份。
-- **減少動態的規則每個檔自帶一份**（`chrome.css`／`components.css`／`dice.css`／`detail.css`
-  各一個 `@media (prefers-reduced-motion: reduce)`；`/tree` 另有兩個區塊收在
+- **每一條 `transition` 都要指名 token 曲線**（`--e-out` hover／按壓／光暈／進場；`--e-in-out`
+  兩端都要停穩的位移；`--e-spring` **只給狀態切換**——目前只有切換鈕被勾選與 `/tree` 篩選面板
+  開合兩處）。裸的 `ease` 由 `tokens.test.ts` 的「過場曲線」擋住。
+  ⚠️ `--t-med`／`--slide-ms` **不准動**：`tree-canvas.ts` 的 `cssMs()` 讀它們當
+  `CENTER_MS`／`FILTERS_MS`／`SLIDE_MS`。只換曲線不換長度是安全的。
+- **按下去要有回饋**：`transform: scale(var(--p-press))`，`transform` 的過場長度走 `--t-press`。
+  ⚠️ **不要在 `:active` 裡寫 `transition-duration: var(--t-press)`**——那是單值，會把同一份
+  清單裡每個屬性的長度一起覆寫掉（切換鈕的 spring 就是這樣被關掉的）。
+  ⚠️ 停用的按鈕要 `:not(:disabled)`。
+- **進場動畫**：`[data-enter] :is(.home-card, .guide-card, .dice-card)` 掛 `rise`（`base.css`）。
+  `--i` 由 Astro 在建置時寫成 inline style，**夾上限的動作只在 CSS**
+  （`min(var(--i, 0), var(--p-stagger-max))`），模板不准自己 `Math.min`。
+  ⚠️ `data-enter` 由 `Base.astro` `<head>` 裡一支**同步的 `is:inline` script** 掛上、載入後由
+  頁尾那支 script 的 `setTimeout` 移除。兩端都不能省：不是 `is:inline` 就會被打包成 defer
+  （卡片先以定位狀態進 DOM）；不移除的話 `/dice` 用 `[hidden]` 篩選切回來時動畫會重播。
+  **不能改用 `animationend`**——`display: none` 的元素不派發那個事件。
+  ⚠️ **刻意不寫成伺服器端輸出的 `<html data-enter>`**：那樣沒有 JS 的環境會永遠留著它。
+  ⚠️ 那段期間 `animation-fill-mode: both` 的結束值會壓過 `:hover` 的 transform，載入後約一秒
+  內卡片 hover 不會抬起。已知且刻意接受。
+- **動畫長度一律用 `cssMs()` 從 CSS 讀**，JS 不寫第二份——實作只有一份，在
+  **`src/lib/css-ms.ts`**（`cssMs` 給時間值、`cssNumber` 給 `--p-stagger-max` 這種無單位的）。
+  ⚠️ **不可以用裸的 `parseFloat`**：Astro 的 CSS 壓縮會把 `440ms` 改寫成 `.44s`，`parseFloat`
+  拿到的是 **0.44**。而且**只在建置產物裡發生**，`astro dev` 不壓縮，本機完全看不出來。
+  2026-08-26 實際咬到：進場動畫的 `data-enter` 在 ~957ms 就被拿掉，41 張卡片裡 36 張還沒跑完。
+- **測試量卡片幾何前先呼叫 `settleEnter(page)`**（`tests/e2e/probe.ts`）。`[data-enter]` 期間
+  卡片掛著 transform，`boundingBox()` 會帶次像素誤差，而 `animation … both` 的結束值會**壓過
+  `:hover` 的 transform**——D14 的正向控制就是這樣變成「驗到動畫的填充值」而永遠通過的。
+- **減少動態的規則每個檔自帶一份**（`chrome.css`／`components.css`／`dice.css`／`detail.css`／
+  `board.css` 各一個 `@media (prefers-reduced-motion: reduce)`，`sim.astro` 也有一份；`/tree` 另有兩個區塊收在
   `src/pages/tree.astro` 自己的 `<style is:global>` 裡——`#filters.animating`（篩選面板寬度
   過場）與 `#filters-toggle`（三條）各一個），刻意不寫成
   `*{transition-duration:0.01ms!important}`：那會連 opacity 一起關掉，而 `/tree` 的篩選淡出是靠
   opacity 在**傳達資訊**，不是裝飾。
+  ⚠️ **reduce 的覆寫選擇器要跟被覆寫的那一條長得一模一樣**，`:is()` 的包法也要一樣：
+  `:is()` 的具體度等於它引數裡最高的那一個，攤開來寫會比包起來寫低一階而輸掉。
+  2026-08-26 實測踩過（`/board` 與 `/tree` 的按壓在 reduce 之下照樣縮，E2E 的 D18 抓到）。
   ⚠️ **`tokens.css` 也有一個 reduce 區塊，而且它是唯一一個改 token 而不是改元件的**：
   重新宣告 `--face-lift`，把下緣硬邊從 `calc(2px + var(--p-lift))` 壓回 2px。理由與「為什麼
   不能在元件的 reduce 區塊裡覆寫 `--p-lift`」寫在該處——**自訂屬性的 `var()` 代換是在宣告
@@ -384,7 +414,7 @@ npm run compare -- <beforeURL> <afterURL>  # computed-style 逐元素比對，�
 
 | 檔 | 放什麼 | 誰載 |
 |---|---|---|
-| `tokens.css` | `:root` 的七組 token（間距／圓角／字級／表面／陰影與節奏／面的質感／排印）——**唯一**允許定義 token 的地方 | Base |
+| `tokens.css` | `:root` 的八組 token（間距／圓角／字級／表面／陰影／面的質感／排印／動效）——**唯一**允許定義 token 的地方 | Base |
 | `base.css` | 全站重置（`*`／`html`／`body`／`main`／`footer`／`a`／`pre`）＋ `.sr-only` | Base |
 | `chrome.css` | 全站導覽列 `#site-nav`（含「遊戲介紹」下拉） | Base |
 | `content.css` | 靜態內容頁共用 `.page`（首頁／圖鑑／遊戲介紹）＋首頁訪客計數器 `#hit-counter`＋詞彙頁 `.kw-*` | Base |

--- a/src/components/DiceCard.astro
+++ b/src/components/DiceCard.astro
@@ -25,9 +25,14 @@ interface Props {
   upgradeCostTable: UpgradeCostTable | null;
   /** 官方基本能力值與強化數據；沒有這顆的資料就整塊不顯示（不要印一塊空面板）。 */
   stats: DiceStatEntry | null;
+  /** 這張卡片在列表裡的序號，寫成 `--i` 給進場動畫排 stagger（src/styles/base.css）。
+   *  ⚠️ 名字刻意不叫 `index`——那個已經被上面的 GlossaryIndex 佔走了，兩個都叫 index
+   *  會是「同一個名字兩件事」。⚠️ **不要在這裡夾上限**：夾的動作在 CSS
+   *  （`min(var(--i), var(--p-stagger-max))`），寫在這裡就是同一個上限散成兩份。 */
+  enterIndex: number;
 }
 
-const { node, gameId, index, whitelist, glossary, upgradeCostTable, stats } = Astro.props;
+const { node, gameId, index, whitelist, glossary, upgradeCostTable, stats, enterIndex } = Astro.props;
 
 const desc = renderStaticText(node.description, whitelist, glossary, index);
 const awakening = node.awakening ? renderStaticText(node.awakening, whitelist, glossary, index) : null;
@@ -41,7 +46,7 @@ const maxUpgrade = upgradeTableApplies(upgradeCostTable, node)
 const modeName = `stat-mode-${node.id}`;
 ---
 
-<article class="dice-card" id={`n${node.id}`} data-branch={node.branch} data-type={node.type}>
+<article class="dice-card" id={`n${node.id}`} data-branch={node.branch} data-type={node.type} style={`--i:${enterIndex}`}>
   <!-- 卡片本文是「第 0 層」。關鍵字的就地視圖會蓋在它上面，換頁時它跟著往左退、淡出，
        跟 /tree 詳情面板的過場同一種動作——所以它必須是一個可以整塊 transform 的元素，
        不能是一堆散落在 .dice-card 底下的兄弟節點。 -->

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -65,6 +65,23 @@ const imageUrl = new URL('/favicon.png', Astro.site).href;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!--
+      data-enter：進場動畫的總開關，規則在 src/styles/base.css。
+      ⚠️ 三件事綁在一起，動其中一件之前先讀完：
+      (1) 必須是 `is:inline` 而且留在這裡（head、任何卡片之前）。Astro 的一般 script 會被
+          打包成 type=module，也就是 defer——要等整份 HTML 解析完才跑，卡片會先以「已經
+          定位」的樣子進 DOM，之後才被套上起點。同步的 inline script 在解析到卡片之前就
+          已經把屬性掛好了（建置產物確認過：它排在 title 之前，第一張卡片之前）。
+      (2) 不要改回伺服器端輸出的 html 屬性：那樣沒有 JS 的環境會永遠留著它，動畫會一直掛在
+          卡片上。2026-08-26 實測那會咬到 E2E 的 C11（javaScriptEnabled: false 之下
+          Playwright 的 actionability 一直判定元素 not stable，30 秒逾時）。由腳本掛的話，
+          沒有 JS ＝ 完全沒有進場動畫，順帶也不會有「/dice 用 [hidden] 篩選、切回來時動畫
+          重播」的問題。
+      (3) 拿掉它的 setTimeout 在頁尾那支 script 裡，理由寫在那裡。
+    -->
+    <script is:inline>
+      document.documentElement.setAttribute('data-enter', '');
+    </script>
     <title>{SITE_NAME} | {title}</title>
     <!--
       canonical：告訴搜尋引擎「這一頁的正規網址是哪一個」。同一份內容被多個網址打得到時
@@ -158,6 +175,23 @@ const imageUrl = new URL('/favicon.png', Astro.site).href;
       // /tree 有。/tree 會由 tree-canvas.ts 再裝一次，兩者寫同一個值、互不干擾。
       import { installNavHeight } from '../lib/nav-height.js';
       installNavHeight();
+
+      // 進場動畫跑完就把 data-enter 拿掉，否則 /dice 用 [hidden] 篩選、卡片切回來時
+      // animation 會重播（display: none 的元素重新顯示時動畫會從頭跑）。
+      // ⚠️ 不能改用 animationend 收尾：display: none 的元素不派發那個事件，41 張卡片裡只要
+      // 有一張正被篩掉就永遠等不到最後一張。
+      // ⚠️ 長度一律從 CSS 讀，不要在這裡寫第二份數字（CLAUDE.md 的規則）。三個值都要讀：
+      // 動畫本身 + 最大延遲階數 × 每階，最後再加一點餘裕。
+      // ⚠️ **一定要用 cssMs() 不是裸的 parseFloat**：Astro 的 CSS 壓縮會把 `440ms` 改寫成
+      // `.44s`，parseFloat 會拿到 0.44 而不是 440，於是 data-enter 在 ~957ms 就被拿掉、
+      // 41 張卡片裡 36 張的動畫還沒跑完就被切斷（2026-08-26 code review 抓到，實測過）。
+      // 這件事**只在建置產物裡發生**，astro dev 不壓縮，本機開發完全看不出來。
+      // ⚠️ --p-stagger-max 是無單位的純數字，要走 cssNumber() 不是 cssMs()。
+      import { cssMs, cssNumber } from '../lib/css-ms.js';
+      window.setTimeout(
+        () => document.documentElement.removeAttribute('data-enter'),
+        cssMs('--t-slow', 440) + cssNumber('--p-stagger-max', 8) * cssMs('--p-stagger', 80) + 100,
+      );
 
       // <details> 唯一缺的兩件事：點到選單外面、以及按 Esc，都要收起來。
       // 沒有這兩條的話，選單一開就只能再點一次 summary 才關得掉——在手機上等於擋住半頁。

--- a/src/lib/css-ms.ts
+++ b/src/lib/css-ms.ts
@@ -1,0 +1,49 @@
+/**
+ * 從 `:root` 讀一個時間類的 CSS 變數，換算成毫秒。
+ *
+ * CLAUDE.md 明訂「動畫長度一律從 CSS 讀，JS 不寫第二份」——這支就是那個「一份」。
+ * 2026-08-26 之前它有兩份逐字相同的複本（`src/scripts/tree-canvas.ts` 的 `cssMs()` 與
+ * `src/pages/dice.astro` 的 `SLIDE_MS`），PR ⑥ 又寫了第三份，而**那一份漏了 `s` 的分支**。
+ *
+ * ⚠️ **`s` 那條分支不是防禦性程式碼，是必要的**：Astro 的 CSS 壓縮會把
+ * `--t-slow: 440ms` 改寫成 `--t-slow: .44s`（少一個字元）。用裸的 `parseFloat` 讀會拿到
+ * **0.44**，而不是 440——差三個數量級，而且**只在建置產物裡發生**，`astro dev` 不壓縮，
+ * 本機開發完全看不出來。
+ *
+ * 實際咬過（2026-08-26 code review 抓到）：`Base.astro` 用 `parseFloat` 算「進場動畫跑完
+ * 沒有」的時間，於是 `data-enter` 在 ~957ms 就被拿掉，量到那一格**41 張卡片裡有 36 張的
+ * `rise` 還沒跑完**，規則一消失它們就直接跳到終點。
+ *
+ * ⚠️ 不要為了「順便支援」而加上 `parseFloat` 的裸數字分支：無單位的時間值在 CSS 裡是
+ * 無效的，讀到那種東西代表變數名打錯或值寫錯，退回 fallback 才是對的。
+ *
+ * @param name 變數名，含前置的兩個連字號（例：`'--t-slow'`）。
+ * @param fallback 讀不到或解析不出正數時的退路（沒有版面的環境如單元測試的 linkedom）。
+ */
+export function cssMs(name: string, fallback: number): number {
+  if (typeof getComputedStyle !== 'function' || typeof document === 'undefined') return fallback;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return msFromCss(raw, fallback);
+}
+
+/**
+ * 純字串版，方便單元測試直接餵值進來（`getComputedStyle` 在 linkedom 底下拿不到東西）。
+ * ⚠️ 順序不能反：`'440ms'` 也是 `.endsWith('s')`，先判 `ms` 才不會被當成 440 秒。
+ */
+export function msFromCss(raw: string, fallback: number): number {
+  const ms = raw.endsWith('ms') ? parseFloat(raw)
+    : raw.endsWith('s') ? parseFloat(raw) * 1000
+      : NaN;
+  return Number.isFinite(ms) && ms > 0 ? ms : fallback;
+}
+
+/**
+ * 無單位的純數字變數（目前只有 `--p-stagger-max`）。
+ * ⚠️ 這種**不可以**走 `cssMs()`：它會因為結尾沒有 `s`／`ms` 而一路退回 fallback，
+ * 而 fallback 恰好也是對的值，於是「CSS 改了 JS 沒跟上」這件事永遠不會被發現。
+ */
+export function cssNumber(name: string, fallback: number): number {
+  if (typeof getComputedStyle !== 'function' || typeof document === 'undefined') return fallback;
+  const n = parseFloat(getComputedStyle(document.documentElement).getPropertyValue(name));
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}

--- a/src/pages/dice.astro
+++ b/src/pages/dice.astro
@@ -96,10 +96,11 @@ const BRANCHES = Object.entries(BRANCH_ZH);
     </div>
 
     <div id="codex-grid" class="codex-grid">
-      {nodes.map(node => (
+      {nodes.map((node, i) => (
         <DiceCard
           node={node}
           gameId={gameIds.get(node.id)}
+          enterIndex={i}
           index={index}
           whitelist={whitelist}
           glossary={glossary}
@@ -119,6 +120,8 @@ const BRANCHES = Object.entries(BRANCH_ZH);
 </Base>
 
 <script>
+  import { cssMs } from '../lib/css-ms.js';
+
   // --- 篩選 ---
   // 勾選框 → 隱藏不符合的卡片。刻意不用 URL 狀態同步（那是 /tree 的契約，它有選取節點與
   // 前置鏈要還原）；這一頁重新整理回到全選是可以接受的。
@@ -183,13 +186,10 @@ const BRANCHES = Object.entries(BRANCH_ZH);
   /**
    * 過場長度。**從 CSS 的 --slide-ms 讀**，跟 /tree 的 tree-canvas.ts 同一個理由：JS 只負責
    * 在動畫結束後把 inline style 清乾淨，兩邊數字一旦漂開，收尾會在動畫還沒跑完就發生，
-   * 看起來像被切斷。
+   * 看起來像被切斷。實作在 src/lib/css-ms.ts（全站共用一份，`s`／`ms` 兩種單位都認得——
+   * 建置時 CSS 會被壓縮成 `.28s`，裸的 parseFloat 會讀成 0.28）。
    */
-  const SLIDE_MS = (() => {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue('--slide-ms').trim();
-    const ms = raw.endsWith('ms') ? parseFloat(raw) : raw.endsWith('s') ? parseFloat(raw) * 1000 : NaN;
-    return Number.isFinite(ms) && ms > 0 ? ms : 280;
-  })();
+  const SLIDE_MS = cssMs('--slide-ms', 280);
 
   /** 使用者要求減少動態時直接瞬間切換。CSS 那邊也關掉了 transition，這裡是同一個決定的另一半。 */
   const canAnimate = () =>

--- a/src/pages/guide/index.astro
+++ b/src/pages/guide/index.astro
@@ -32,8 +32,8 @@ const pages = GUIDE_PAGES.map(page => ({
     </p>
 
     <div class="guide-cards">
-      {pages.map(page => (
-        <a class="guide-card" href={`/guide/${page.slug}`}>
+      {pages.map((page, i) => (
+        <a class="guide-card" href={`/guide/${page.slug}`} style={`--i:${i}`}>
           <span class="guide-swatch" aria-hidden="true">
             {page.colors.map(c => <span style={`background:${c}`}></span>)}
           </span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,15 +27,15 @@ const latestDataInRecent = latestDataEntry !== undefined && recent.includes(late
   <section class="page home-hero">
     <h1>Random Dice 2 wiki</h1>
     <div class="home-links">
-      <a class="home-card" href="/tree">
+      <a class="home-card" href="/tree" style="--i:0">
         <h2>骰子樹 →</h2>
         <p>可平移縮放的全樹畫布，點節點看前置鏈與累計解鎖成本。</p>
       </a>
-      <a class="home-card" href="/dice">
+      <a class="home-card" href="/dice" style="--i:1">
         <h2>骰子圖鑑 →</h2>
         <p>{diceCount} 顆骰子的基本效果與 7 骰點覺醒，一頁看完。</p>
       </a>
-      <a class="home-card" href="/guide">
+      <a class="home-card" href="/guide" style="--i:2">
         <h2>遊戲介紹 →</h2>
         <p>骰子描述裡那些帶 # 的官方標記是什麼意思。</p>
       </a>

--- a/src/pages/sim.astro
+++ b/src/pages/sim.astro
@@ -157,11 +157,19 @@ const optional = [...ctx.optional]
     background: var(--surface-1);
     border: 1px solid var(--border-strong);
     border-radius: var(--r-sm);
-    transition: background var(--t-fast);
+    transition:
+      background var(--t-fast) var(--e-out),
+      transform var(--t-press) var(--e-out);
   }
 
   #sim-toolbar button:hover:not(:disabled) {
     background: var(--surface-3);
+  }
+
+  /* 按下去縮一下（2026-08-26 PR ⑥）。⚠️ `:not(:disabled)`：模擬器的按鈕會在跑不動的時候
+     停用，按不動的東西不該有按下去的回饋。 */
+  #sim-toolbar button:not(:disabled):active {
+    transform: scale(var(--p-press));
   }
 
   #sim-toolbar button:disabled {
@@ -629,6 +637,22 @@ const optional = [...ctx.optional]
        <main> 是 flex: 1，footer 變高只會讓畫布跟著縮，不會把捲軸叫回來。 */
     body:has(#canvas-host) footer {
       padding-bottom: calc(var(--space-4) + var(--sim-panel-h, 42dvh));
+    }
+  }
+
+  /* 減少動態：模擬器這一份。理由與寫法見 chrome.css 檔尾同一段。
+     ⚠️ 這一頁 2026-08-26 之前沒有這一段（它只有一條沒有曲線的 background 過場）；
+     PR ⑥ 給按鈕加上按壓回饋之後才需要。 */
+  @media (prefers-reduced-motion: reduce) {
+    #sim-toolbar button {
+      transition: none;
+    }
+    /* ⚠️ 選擇器要跟上面那條**一模一樣**，`:not(:disabled)` 也要帶上：
+       `#sim-toolbar button:not(:disabled):active` 是 (1,2,1)，少了 `:not()` 只有 (1,1,1)，
+       會被壓過去。2026-08-26 實測踩到——reduce 之下按鈕照樣縮，是 code review 抓出來的，
+       而 D18 當時沒有把 /sim 列進去、D14 只驗 transition-duration 不驗 transform。 */
+    #sim-toolbar button:not(:disabled):active {
+      transform: none;
     }
   }
 </style>

--- a/src/pages/tree.astro
+++ b/src/pages/tree.astro
@@ -183,7 +183,11 @@ const TYPES: Array<[string, string]> = [
   }
   #filters.animating {
     overflow: hidden;
-    transition: width var(--t-med) var(--slide-ease);
+    /* 開合走 --e-spring（2026-08-26 PR ⑥）：面板開合是「狀態真的變了」，spec §2 決策 4
+       指定的兩個 spring 使用點之一（另一個是切換鈕被勾選）。⚠️ 長度仍是 --t-med，因為
+       `src/scripts/tree-canvas.ts` 的 FILTERS_MS 讀的是它——只換曲線不換長度，JS 的收尾
+       時機不受影響。 */
+    transition: width var(--t-med) var(--e-spring);
   }
   @media (prefers-reduced-motion: reduce) {
     #filters.animating {
@@ -291,6 +295,15 @@ const TYPES: Array<[string, string]> = [
   #filters-toggle:hover {
     border-color: var(--border-strong);
   }
+  /* 按下去縮一下（2026-08-26 PR ⑥）。⚠️ #filters-toggle 縮的是**按鈕本體**，它的 ::after
+     箭頭已經有自己的 transform（展開時轉向），兩者不會互相蓋掉——一個在元素上、一個在
+     偽元素上。 */
+  :is(#filters-toggle, #filter-clear, #branch-chips button) {
+    transition: transform var(--t-press) var(--e-out);
+  }
+  :is(#filters-toggle, #filter-clear, #branch-chips button):active {
+    transform: scale(var(--p-press));
+  }
   /* 展開狀態：箭頭轉向。選擇器綁 aria-expanded，樣式與無障礙狀態不會各講各的。
      桌機的面板是往右邊長出來的，所以箭頭是左右向（▸ 收起／◂ 展開），不是上下。
      手機版是往下掉的抽屜，下面的媒體查詢換回 ▾。 */
@@ -298,7 +311,7 @@ const TYPES: Array<[string, string]> = [
     content: '▸';
     color: var(--muted);
     font-size: var(--fs-xs);
-    transition: transform var(--t-fast) ease;
+    transition: transform var(--t-press) var(--e-out);
   }
   #filters-toggle[aria-expanded='true']::after {
     transform: rotate(180deg);
@@ -314,7 +327,7 @@ const TYPES: Array<[string, string]> = [
     height: 0.5rem;
     border-radius: var(--r-pill);
     background: transparent;
-    transition: background-color var(--t-fast) ease;
+    transition: background-color var(--t-fast) var(--e-out);
   }
   #filters-toggle.active {
     border-color: var(--gold);
@@ -445,6 +458,16 @@ const TYPES: Array<[string, string]> = [
     #filters-toggle::before,
     #filters-toggle::after {
       transition: none;
+    }
+    /* ⚠️ 這兩條的選擇器要跟上面那兩條**一模一樣**（連 `:is()` 的包法都要一樣）。
+       `:is()` 的具體度等於引數裡最高的那一個——`:is(#filters-toggle, …, #branch-chips button):active`
+       是 (1,1,1)，攤開來寫的 `#filters-toggle:active` 只有 (1,1,0)，會被壓過去。
+       2026-08-26 實測踩到：reduce 之下按鈕照樣縮，是 E2E 的 D18 抓出來的。 */
+    :is(#filters-toggle, #filter-clear, #branch-chips button) {
+      transition: none;
+    }
+    :is(#filters-toggle, #filter-clear, #branch-chips button):active {
+      transform: none;
     }
   }
 </style>

--- a/src/scripts/tree-canvas.ts
+++ b/src/scripts/tree-canvas.ts
@@ -3,6 +3,7 @@
 // 節點互動（詳情面板、搜尋、篩選……後續任務）會接著在這支腳本上擴充。
 import rawData from '../generated/tree.json';
 import { renderTree } from '../lib/render.js';
+import { cssMs } from '../lib/css-ms.js';
 import {
   DESKTOP_ICON_TARGET_PX,
   MOBILE_ICON_TARGET_PX,
@@ -29,19 +30,7 @@ const data = rawData as unknown as TreeData;
 // ?node=」反查該節點所屬分支，純資料處理、不依賴任何 DOM，提前宣告沒有副作用。
 const byId = new Map(data.nodes.map(n => [n.id, n]));
 
-/**
- * 從 :root 讀一個時間類的 CSS 自訂屬性，換算成毫秒。
- *
- * 動畫長度只能有一個來源：CSS 負責過場，JS 只負責在過場結束後把 inline style 清乾淨。
- * 兩邊各寫一份的話，改了 CSS 而忘了改 JS，收尾就會在動畫還沒跑完時發生（CLAUDE.md 有記）。
- * 取不到值（單元測試的 linkedom 沒有 getComputedStyle）時回 fallback——那條路本來就不做動畫。
- */
-function cssMs(name: string, fallback: number): number {
-  if (typeof getComputedStyle !== 'function' || typeof document === 'undefined') return fallback;
-  const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  const ms = raw.endsWith('ms') ? parseFloat(raw) : raw.endsWith('s') ? parseFloat(raw) * 1000 : NaN;
-  return Number.isFinite(ms) && ms > 0 ? ms : fallback;
-}
+// 動畫長度：cssMs() 的實作與注意事項在 src/lib/css-ms.ts（全站共用一份）。
 
 // 導覽列高度：實作與說明在 src/lib/nav-height.ts（全站共用，見那裡的註解）。
 updateNavHeight();

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -134,3 +134,50 @@ pre {
   white-space: nowrap;
   border: 0;
 }
+
+/* ==========================================================================
+   進場動畫（2026-08-26 PR ⑥）
+   --------------------------------------------------------------------------
+   卡片列表載入時由上往下依序浮出。`--i` 是卡片在列表裡的序號，由 Astro 在建置時寫成
+   inline style；夾住上限的動作在**這裡**做，不在模板裡（見 tokens.css 的 --p-stagger-max）。
+
+   ⚠️ `@keyframes` 是全域的，放哪個檔都一樣有效——所以刻意收在 base.css 這個「全域層」，
+   不要在 components.css 與 dice.css 各寫一份。三種卡片共用同一段動畫。
+
+   ⚠️ 整段掛在 `[data-enter]` 底下，而那個屬性由 Base.astro `<head>` 裡一支 `is:inline` 的
+   腳本掛上、載入後約一秒由另一支腳本移除。兩端都不能省：
+     - `<head>` 裡同步掛（不是伺服器端輸出的 `<html data-enter>`）：沒有 JS 的環境就完全
+       不跑進場動畫，屬性也不會永遠留著。細節見 Base.astro 該處。
+     - 事後移除：`/dice` 的篩選用 `[hidden]`（display: none），切回來時 animation 會**重播**。
+       ⚠️ 不能改用 `animationend` 收尾——`display: none` 的元素不派發那個事件，41 張卡片裡
+       只要有一張被篩掉就永遠等不到。
+   ⚠️ 這段期間 `animation-fill-mode: both` 的結束值會壓過 `:hover` 的 transform，所以載入後
+   約一秒內卡片 hover 不會抬起來。這是已知且刻意接受的——比起為它加一層 class 開關，
+   一秒的視窗換一份更少的狀態機划算。
+
+   ⚠️ 起點的 `opacity: 0` **只存在於 keyframes 裡**，不寫成元素的靜態樣式：CSS 若整份載不到，
+   卡片是正常可見的，不是一片空白。 */
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+[data-enter] :is(.home-card, .guide-card, .dice-card) {
+  animation: rise var(--t-slow) var(--e-out) both;
+  animation-delay: calc(min(var(--i, 0), var(--p-stagger-max)) * var(--p-stagger));
+}
+
+/* 減少動態：進場整組關掉。
+   ⚠️ 用 `animation: none` 而不是把長度歸零——長度歸零時 `both` 仍然成立，帶延遲的卡片會在
+   延遲跑完之前維持在起點（opacity: 0），使用者會看到一頁慢慢補齊的空白格。 */
+@media (prefers-reduced-motion: reduce) {
+  [data-enter] :is(.home-card, .guide-card, .dice-card) {
+    animation: none;
+  }
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -181,6 +181,18 @@
 #board-export-img { max-width: 100%; border-radius: var(--r-md); }
 .board-hint { color: var(--muted); font-size: var(--fs-sm); }
 
+/* 按下去縮一下（2026-08-26 PR ⑥）。/board 是全站最需要這個的一頁——它整頁都是點與拖，
+   而手機上沒有 hover 可以講「我碰到了」。
+   ⚠️ **刻意不含 `.board-cell`**：格子的主要互動是拖曳，而 `:active` 在整段拖曳期間都成立，
+   格子會從按下的那一刻一路縮著直到放開。抓起來的回饋由 .dragging 那一路負責，不是這裡。
+   ⚠️ `.pips-row button:disabled` 也要排除：按不動的東西不該有按下去的回饋。 */
+:is(#board-tools button, #picker-close, .picker-dice, .pips-row button) {
+  transition: transform var(--t-press) var(--e-out);
+}
+:is(#board-tools button, #picker-close, .picker-dice, .pips-row button):not(:disabled):active {
+  transform: scale(var(--p-press));
+}
+
 /* 拖曳影像。⚠️ pointer-events: none 是必要的：落點判定用 elementFromPoint，
    影像跟在指標下方，能接事件的話就永遠只抓得到影像自己。 */
 .drag-ghost {
@@ -263,3 +275,18 @@
   }
 }
 
+/* 減少動態：骰盤這一份。理由與寫法見 chrome.css 檔尾同一段。
+   ⚠️ 這個檔 2026-08-26 之前**沒有這一段**，因為它一條 transition 都沒有；PR ⑥ 給按鈕加上
+   按壓回饋之後才需要。新增元件時記得同一件事：動效與「怎麼關掉它」要放在同一個檔。 */
+@media (prefers-reduced-motion: reduce) {
+  /* ⚠️ 選擇器要跟上面那兩條**一模一樣**，包含 `:is()` 的包法與 `:not(:disabled)`。
+     `:is()` 的具體度等於它引數裡最高的那一個——`:is(#board-tools button, …):not(:disabled):active`
+     是 (1,2,1)，而攤開來寫的 `#board-tools button:active` 只有 (1,1,1)，會被壓過去。
+     2026-08-26 實測踩到：reduce 之下按鈕照樣縮，是 E2E 的 D18 抓出來的。 */
+  :is(#board-tools button, #picker-close, .picker-dice, .pips-row button) {
+    transition: none;
+  }
+  :is(#board-tools button, #picker-close, .picker-dice, .pips-row button):not(:disabled):active {
+    transform: none;
+  }
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -38,7 +38,7 @@
   color: var(--fg);
   text-decoration: none;
   font-weight: 600;
-  transition: color var(--t-fast) ease;
+  transition: color var(--t-fast) var(--e-out);
 }
 
 #site-nav a:hover {
@@ -146,7 +146,7 @@
   font-weight: 600;
   color: var(--fg);
   user-select: none;
-  transition: color var(--t-fast) ease;
+  transition: color var(--t-fast) var(--e-out);
 }
 #site-nav .nav-menu > summary::-webkit-details-marker {
   display: none;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -14,10 +14,13 @@
   box-shadow: var(--face);
   color: var(--fg);
   text-decoration: none;
+  /* transform 走 --t-press、色與影走 --t-fast（2026-08-26 PR ⑥）：位移是「這東西在動」，
+     要比顏色變化更即時。⚠️ 不要改成在 :active 裡寫 `transition-duration: var(--t-press)`
+     ——那是**單值**，會把同一份清單裡每一個屬性的長度一起覆寫掉。 */
   transition:
-    border-color var(--t-fast) ease,
-    box-shadow var(--t-fast) ease,
-    transform var(--t-fast) ease;
+    border-color var(--t-fast) var(--e-out),
+    box-shadow var(--t-fast) var(--e-out),
+    transform var(--t-press) var(--e-out);
 }
 :is(.home-card, .guide-card):hover,
 :is(.home-card, .guide-card):focus-visible {
@@ -25,6 +28,17 @@
   box-shadow: var(--face-lift);
   transform: translateY(calc(-1 * var(--p-lift)));
   text-decoration: none;
+}
+/* 按下去的回饋（2026-08-26 PR ⑥）。這張 PR 之前全站**一條 :active 規則都沒有**——桌機還有
+   hover 可以講「我碰到了」，手機從按下去到頁面換掉之間完全沒有任何回應。
+   ⚠️ 具體度要贏 :hover：`:is(...):active` 跟 `:is(...):hover` 同具體度，靠寫在後面取勝。
+   移到這條規則前面的話手指按住時仍然是 hover 的樣子（手機的 :hover 會黏住），等於沒做。
+   ⚠️ transform 要**同時**寫抬升與縮放，不能只寫 scale：後者會整個蓋掉 hover 的
+   translateY，卡片按下去會先掉回原位再縮，看起來像抖了一下。
+   影子收回 --face（跟靜止同一階）：抬起來的東西被按下去，影子要跟著收，不然是「浮著又被壓扁」。 */
+:is(.home-card, .guide-card):active {
+  box-shadow: var(--face);
+  transform: translateY(calc(-1 * var(--p-lift))) scale(var(--p-press));
 }
 .home-card h2 {
   margin: 0 0 var(--space-2);
@@ -120,11 +134,20 @@
      撐換行的列距，結果在 /tree 的工具列裡把鈕的中心往上推 2.0px，E2E 的 P（工具列共用同一
      條中線）直接紅。 */
   margin: 0;
+  /* 曲線按**觸發它的是哪一種狀態**分兩組，不是按屬性隨手分（2026-08-26 PR ⑥）：
+       color／border-color 是 :hover 會改的 → --e-out，快、不回彈。
+       background-color／box-shadow **只有被勾選才會改**（:hover 那條規則沒碰這兩個，
+       翻上去看得到）→ --e-spring，走 --t-med。
+     這是 spec §2 決策 4「--e-spring 只給狀態切換」唯一能落地的寫法：一顆鈕上兩種觸發共用
+     一份 transition，只能靠屬性把它們分開。⚠️ 哪天給 .chip:hover 加上 background 或
+     box-shadow，hover 就會跟著回彈——要嘛別加，要嘛那時候再想怎麼拆。
+     ⚠️ 回彈需要時間才讀得出來，--e-spring 配 --t-fast（90ms）會看起來只是普通的漸變。 */
   transition:
-    color var(--t-fast) ease,
-    background-color var(--t-fast) ease,
-    box-shadow var(--t-fast) ease,
-    border-color var(--t-fast) ease;
+    color var(--t-fast) var(--e-out),
+    border-color var(--t-fast) var(--e-out),
+    transform var(--t-press) var(--e-out),
+    background-color var(--t-med) var(--e-spring),
+    box-shadow var(--t-med) var(--e-spring);
 }
 .chip input {
   position: absolute;
@@ -152,7 +175,17 @@
      邊框那一圈才是被強調的東西——往外發光的話它會跟隔壁那顆的光暈糊在一起。
      前一行同樣是 color-mix 的 fallback：不支援的引擎退回一層中性內陰影，不會變成沒有。 */
   box-shadow: inset 0 0 11px rgb(255 255 255 / 6%);
-  box-shadow: inset 0 0 11px color-mix(in srgb, var(--branch, var(--gold)) 22%, transparent);
+  box-shadow: inset 0 0 11px color-mix(in srgb, var(--branch, var(--gold)) calc(var(--p-glow) * 100%), transparent);
+}
+/* 按下去縮一下。切換鈕是這一頁最常被戳的東西，而它「有沒有生效」是靠底色變化——
+   底色的過場走 --e-spring／--t-med（見上），200ms 對「我按到了嗎」來說太慢，這條補上
+   80ms 就到位的即時回饋（transform 的長度在上面那份清單裡就是 --t-press）。
+   ⚠️ 寫在 :hover 與 :has(input:checked) **兩條之後**：三條同具體度，靠後到者勝。
+   ⚠️ **不要在這裡寫 `transition-duration: var(--t-press)`**：那個單值會把同一份清單裡的
+   background-color 與 box-shadow 一起壓成 80ms，而按下切換鈕的那一刻 :active 與 :checked
+   是同時發生的——回彈曲線就在它唯一該出現的互動上被關掉了。 */
+.chip:active {
+  transform: scale(var(--p-press));
 }
 /* 焦點框畫在整顆鈕上。checkbox 自己是透明的，:focus-visible 落在它身上時看不到任何東西。 */
 .chip:has(input:focus-visible),
@@ -182,7 +215,7 @@
 .chip .branch-dot {
   margin-right: 0;
   opacity: 0.45;
-  transition: opacity var(--t-fast) ease;
+  transition: opacity var(--t-fast) var(--e-out);
 }
 .chip:has(input:checked) .branch-dot {
   opacity: 1;
@@ -270,7 +303,10 @@
     transition: none;
   }
   .home-card:hover,
-  .guide-card:hover {
+  .guide-card:hover,
+  .home-card:active,
+  .guide-card:active,
+  .chip:active {
     transform: none;
   }
 }

--- a/src/styles/dice.css
+++ b/src/styles/dice.css
@@ -52,10 +52,11 @@
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   box-shadow: var(--face);
+  /* transform 走 --t-press、色與影走 --t-fast，理由同 components.css 的卡片。 */
   transition:
-    border-color var(--t-fast) ease,
-    box-shadow var(--t-fast) ease,
-    transform var(--t-fast) ease;
+    border-color var(--t-fast) var(--e-out),
+    box-shadow var(--t-fast) var(--e-out),
+    transform var(--t-press) var(--e-out);
 }
 /* 頂緣 3px 的屬性色漸層——這是卡片上**唯一**的分支色（Yuki 2026-08-26 拍板拿掉左緣色條，
    兩條同色的線圍成「⌐」太吵，留上面那條就夠）。
@@ -190,7 +191,7 @@
   /* 切檔時只有透明度會變。**尺寸不動這件事不是這裡守的**，是 .stat-v 的 inline-grid 疊放
      （見下面）——41 張卡片排在 CSS grid 裡，任何一顆 pill 變寬都可能多擠出一列而把同一列的
      鄰居一起撐高，同 /tree 工具列那條「會出現／消失的東西尺寸不准變」的教訓。 */
-  transition: opacity var(--t-fast) ease;
+  transition: opacity var(--t-fast) var(--e-out);
 }
 /* ⚠️ 字距走 --ls-label（跟 .meta 同源），並且**只有這個 token 可以動**：pill 會 wrap，
    字距一改就是 pill 變寬，而卡片在 CSS grid 的同一列裡會被最寬的鄰居撐高（同下面 .stat-v
@@ -347,11 +348,21 @@
   font: inherit;
   line-height: 1;
   cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--e-out),
+    color var(--t-fast) var(--e-out),
+    transform var(--t-press) var(--e-out);
 }
 .card-term-back:hover,
 .card-term-back:focus-visible {
   background: rgb(255 255 255 / 10%);
   color: var(--fg);
+}
+/* 按下去縮一下（2026-08-26 PR ⑥）。這顆 ← 是關鍵字就地視圖唯一的返回路徑，手機上按了到
+   畫面換掉之間有 --slide-ms 的過場，中間沒有回饋會讓人以為沒按到而連按兩次。
+   ⚠️ 要寫在 :hover 那條之後，同具體度靠後到者勝。 */
+.card-term-back:active {
+  transform: scale(var(--p-press));
 }
 .card-term-title {
   margin: 0;
@@ -378,6 +389,12 @@
     transition: none;
   }
   .dice-card:hover {
+    transform: none;
+  }
+  .card-term-back {
+    transition: none;
+  }
+  .card-term-back:active {
     transform: none;
   }
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -23,7 +23,10 @@
      easing 用 ease-out 系（尾段慢）而不是 `ease`：兩端都慢的曲線在 200–300ms 這種短動畫上
      起步會有一段「頓住」的感覺。 */
   --slide-ms: 280ms;
-  --slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* ⚠️ 這就是 --e-out，同一條曲線的第二個名字。2026-08-26 收成一份——它原本是寫死的第二份
+     `cubic-bezier(0.22, 1, 0.36, 1)`，正是這個 repo 一路在收的漂移類別（--panel、
+     render.ts 的第二份金色）。名字留著是因為它跟 --slide-ms 成對、講的是「換頁」這件事。 */
+  --slide-ease: var(--e-out);
 
   --nature: #ef625e;
   --engineering: #50b7d8;
@@ -126,16 +129,54 @@
      它們一起收進來是視覺決定，得先給 Yuki 看對照圖（2026-08-26 code review 提出）。 */
   --face-float: inset 0 1px 0 var(--hair), var(--shadow-3);
 
-  /* 微互動的節奏。跟 --slide-ms 是兩回事：那個是換頁，這兩個是 hover／焦點這種即時回饋。 */
-  --t-fast: 120ms;
+  /* 微互動的節奏（2026-08-26 PR ⑥ 依 Yuki 在動效實驗室定的值調整）。
+     跟 --slide-ms 是兩回事：那個是換頁，這幾個是 hover／按壓／進場這種即時回饋。
+     --t-fast 120 → 90ms：hover 的回饋越快越像「這東西在回應我」，120ms 已經開始像延遲。
+     --t-press 比 --t-fast 更短：按下去的回饋要比滑過去的更即時，慢一點就變成「卡了一下」。
+     ⚠️ --t-med **不准動**：`src/scripts/tree-canvas.ts` 的 cssMs() 讀它當 CENTER_MS 與
+     FILTERS_MS，改了要連 JS 的收尾時機一起想。--slide-ms 同理（SLIDE_MS）。 */
+  --t-fast: 90ms;
+  --t-press: 80ms;
   --t-med: 200ms;
+  /* 進場動畫的長度。單獨一階是因為它跟 hover 不是同一件事：hover 要快，進場要慢到讓人
+     看得出「東西是長出來的」。 */
+  --t-slow: 440ms;
 
+  /* 曲線。三條各有明確用途，不要混用。
+     --e-out    尾段慢，起步快：hover、按壓、光暈、進場**一律**用這條。
+     --e-in-out 兩端慢：只給「從 A 移動到 B」而且兩端都要停穩的東西。
+     --e-spring 尾段回彈：**只給狀態切換**（切換鈕被勾選、篩選面板開合）——「東西真的變了」
+                才配回彈。滑鼠滑過 41 張卡片時每張都彈一下會很躁（Yuki 拍板，見 spec §2 決策 4）。 */
+  --e-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --e-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --e-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* 三個「動多少」的量（2026-08-26 PR ⑥ 補齊；--p-lift 是 PR ④ 就有的）。
+     單位刻意不一致是因為它們量的東西不同：抬升是長度、按壓是縮放比例、光暈是混色比例。 */
   /* hover 抬升量。原本是三個檔各自寫死的 `translateY(-2px)`（.home-card／.guide-card／
      .dice-card），收成 token 是為了讓 --face-lift 的下緣硬邊能跟著它一起長——卡片往上抬
      2px、影子的硬邊就要往下多 2px，方向感才對得上。
      ⚠️ E2E 有守：chrome.spec.ts 的「形狀二」會先斷言 hover 真的有 transform（正向控制），
      再驗 reduce 之下被關掉。把這裡改成 0 會讓那條的正向控制紅。 */
   --p-lift: 2px;
+  /* 按下去縮多少。0.985 在 200px 寬的卡片上是 3px，剛好看得出來又不會像在跳。
+     ⚠️ 不要再往下調：卡片一縮，它的圓角與邊框會跟著被縮，低於 0.97 就看得出邊框變細。 */
+  --p-press: 0.985;
+  /* 進場 stagger 的每一階，以及它的階數上限。
+     ⚠️ 兩個一定要一起看：/dice 有 41 張卡片，不夾的話最後一張要等 41 × 80ms ＝ 3.64 秒
+     （Yuki 拍板要夾，見 spec §2 決策 3）。夾在 8 之後最長延遲是 640ms。
+     ⚠️ 上限**刻意做成 token 而不是寫死在三個模板裡的 `Math.min(index, 8)`**：夾的動作在
+     CSS（`min(var(--i), var(--p-stagger-max))`，見 base.css），移除 `data-enter` 的
+     setTimeout 也要用同一個上限算總長度（Base.astro）。寫死就是同一個 8 散在四個地方。 */
+  --p-stagger: 80ms;
+  --p-stagger-max: 8;
+  /* 內發光的混色比例。切換鈕選中時用，0.20 → color-mix 的 20%。
+     ⚠️ **這是一個看得見的數值變動，不只是把既有的值收成 token**：PR ④ 寫死的是 22%，
+     Yuki 在動效實驗室定的是 0.20，這裡照後者。差 2 個百分點，肉眼幾乎分不出來，但
+     「收成 token」與「順手改了值」是兩件事，不寫下來下一個人會以為是打錯的。
+     ⚠️ 它是**無單位小數**不是百分比，因為 color-mix 要的是 `calc(var(--p-glow) * 100%)`；
+     直接寫成 20% 的話那個 calc 會變成 2000%（invalid），整條 box-shadow 靜靜失效。 */
+  --p-glow: 0.20;
 
   /* 小標籤的字距（.meta／.stat-k）。0.1em 在 12px 上是 1.2px，中文小字加了這一階之後
      字與字之間分得開，讀起來是「一排標籤」而不是一團擠在一起的小字。

--- a/tests/e2e/chrome.spec.ts
+++ b/tests/e2e/chrome.spec.ts
@@ -5,7 +5,7 @@
 // 人工看圖才發現的 bug（下拉箭頭被拉成一條金槓、短頁面的 footer 停在畫面中間）——
 // 這一份就是把那類東西釘住。
 import { test, expect } from '@playwright/test';
-import { resolveColor } from './probe';
+import { resolveColor, settleEnter } from './probe';
 
 test('D1. 導覽列沾在視窗頂端，圖鑑的篩選列沾在導覽列正下方，兩者都不被卡片蓋掉', async ({ page }) => {
   await page.goto('/dice');
@@ -316,6 +316,10 @@ test('D14. 減少動態的規則拆到各檔之後沒有漏掉任何一條', asy
     { path: '/dice', selector: '.chip .branch-dot' },
     { path: '/dice', selector: '#site-nav a' },
     { path: '/dice', selector: '#site-nav .nav-menu > summary' },
+    // 2026-08-26 PR ⑥ 新增：這兩個檔在那之前**一條 transition 都沒有**，所以也沒有 reduce
+    // 區塊；按壓回饋加進去之後才需要。新元件加動效時要記得補同一件事。
+    { path: '/board', selector: '#board-tools button' },
+    { path: '/sim', selector: '#sim-toolbar button' },
     // ⚠️ #filters-toggle 本體（tree.astro:279）沒有 transition，過場在 ::after
     // （:297 transform）與 ::before（:310 background-color）兩個偽元素上。讀元素本身的話
     // 正向控制會直接紅，而且是假紅——所以這兩列指定讀虛擬元素。
@@ -356,12 +360,18 @@ test('D14. 減少動態的規則拆到各檔之後沒有漏掉任何一條', asy
   for (const c of HOVER_CASES) {
     await page.emulateMedia({ reducedMotion: null });
     await page.goto(c.path);
+    // ⚠️ 一定要等進場動畫收掉再量（2026-08-26 code review 抓到）。`[data-enter]` 期間
+    // `animation: rise … both` 的結束值會壓過 `:hover` 的 transform，讀到的是
+    // `matrix(1, 0, 0, 1, 0, 0)`——那不是字串 'none'，所以底下的**正向控制照樣通過**，
+    // 而它通過的是動畫的填充值不是 hover。把 `.dice-card:hover { transform }` 整條刪掉，
+    // 這個 case 仍然全綠。三個 path 都要等：/ 與 /guide 的卡片同樣掛著進場動畫。
+    await settleEnter(page);
     const el = page.locator(c.selector).first();
     await expect.soft(el, `${c.path} 上找不到 ${c.selector}`).toBeAttached();
     // 同上一個形狀的理由：找不到就跳過，不要讓 el.hover() 卡 30 秒把整個 test 中止掉。
     if (!(await el.count())) continue;
     // --face-lift 的下緣硬邊：`calc(2px + var(--p-lift))`，hover 時該從 2px 長到 4px。
-    // ⚠️ 一定要等過場跑完再讀（--t-fast 是 120ms），否則讀到的是 2.33px 這種中間值。
+    // ⚠️ 一定要等過場跑完再讀（--t-fast 是 90ms），否則讀到的是 2.33px 這種中間值。
     const edge = (shadow: string) =>
       shadow.match(/rgba?\([^)]*\)\s+0px\s+([\d.]+)px\s+0px\s+0px(?!\s+inset)/)?.[1];
     const shadowOf = () => el.evaluate(n => getComputedStyle(n).boxShadow);
@@ -578,4 +588,179 @@ test('D16. 導覽列的「上次更新」日期走 Archivo', async ({ page, isMo
   const family = await page.locator('.nav-updated')
     .evaluate(el => getComputedStyle(el).fontFamily.split(',')[0]!.replace(/['"]/g, ''));
   expect(family, '.nav-updated 沒吃到 --font-num').toBe('Archivo');
+});
+
+/**
+ * D17. 進場動畫：staggered、夾得住上限、跑完會自己關掉、reduce 之下整組不跑。
+ *
+ * 四件事各自壞掉時畫面都還能看，所以四條都要驗：
+ *  (一) 沒夾上限 → /dice 第 41 張卡片要等 41 × 80ms ＝ 3.64 秒才浮出來（spec §2 決策 3）。
+ *  (二) `data-enter` 沒被移除 → /dice 用 `[hidden]` 篩選，卡片切回來時 animation 會**重播**。
+ *  (三) reduce 之下沒關掉 → 使用者會看到一頁慢慢補齊的空白格，比動畫本身更糟。
+ *  (四) 動畫根本沒掛上 → 上面三條全部「通過」，因為它們驗的都是「不要有」。所以每一條
+ *       都先做正向控制。
+ */
+test('D17. 卡片進場是 staggered 的，延遲夾得住上限，跑完自己關掉', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: null });
+  // ⚠️ 用 domcontentloaded 不是 load：`data-enter` 大約一秒後就被腳本移掉了，等 load
+  // （含 41 張卡片的圖）很可能已經來不及。
+  await page.goto('/dice', { waitUntil: 'domcontentloaded' });
+
+  const read = (n: number) => page.locator('.dice-card').nth(n).evaluate(el => {
+    const cs = getComputedStyle(el);
+    return { name: cs.animationName, delay: cs.animationDelay, fill: cs.animationFillMode };
+  });
+
+  // 正向控制：動畫真的掛上去了，底下三條才有意義。
+  const first = await read(0);
+  expect(first.name, '第一張卡片沒有進場動畫——底下三條都會變成「不要有」的空斷言').toBe('rise');
+  expect(first.fill, 'fill-mode 不是 both，帶延遲的卡片在延遲跑完前不會停在起點').toBe('both');
+  expect(first.delay, '第一張卡片不該有延遲').toBe('0s');
+
+  const stagger = await page.evaluate(() =>
+    parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--p-stagger')));
+  const max = await page.evaluate(() =>
+    parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--p-stagger-max')));
+  const ms = (delay: string) => Math.round(parseFloat(delay) * 1000);
+
+  expect(ms((await read(1)).delay), '第二張卡片的延遲不是一階 --p-stagger').toBe(stagger);
+  // 夾上限：第 max 張與最後一張（第 41 張）必須是同一個延遲。
+  const capped = stagger * max;
+  expect(ms((await read(max)).delay), `第 ${max} 張的延遲不是上限值`).toBe(capped);
+  expect(ms((await read(40)).delay),
+    `第 41 張的延遲沒有被夾住（上限應該是 ${capped}ms）——不夾的話它要等 ${41 * stagger}ms`)
+    .toBe(capped);
+
+  // 跑完之後 data-enter 要消失，否則 [hidden] 篩選切回來時動畫會重播。
+  await expect.poll(
+    () => page.evaluate(() => document.documentElement.hasAttribute('data-enter')),
+    { timeout: 5000, message: 'data-enter 一直沒被移除，/dice 篩選切回來時卡片會重播進場' },
+  ).toBe(false);
+  expect((await read(0)).name, 'data-enter 移掉之後卡片還掛著動畫').toBe('none');
+});
+
+/**
+ * D17c. `data-enter` 不准在動畫還沒跑完就被拿掉。
+ *
+ * D17 只驗「它最後有被拿掉」，**拿掉的時機對不對完全沒有守**。2026-08-26 code review 抓到
+ * 一個只在**建置產物**裡發生的 bug：`Base.astro` 用裸的 `parseFloat` 讀 `--t-slow`，而 Astro
+ * 的 CSS 壓縮把 `440ms` 改寫成 `.44s`——`parseFloat('.44s')` 是 **0.44**，計時器因此短了整整
+ * 一個動畫長度。實測那一格 **41 張卡片有 36 張的 rise 還沒跑完**，規則一消失它們直接跳到終點。
+ * `astro dev` 不壓縮，所以本機開發與任何靜態檢查都看不出來。
+ *
+ * ⚠️ 這條要在頁面裡逐幀取樣，不能事後 `page.evaluate` 量一次：`data-enter` 消失之後
+ * `getAnimations()` 就回空陣列，什麼都量不到了。
+ */
+test('D17c. data-enter 是在全部卡片的進場動畫跑完之後才被拿掉', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: null });
+  await page.addInitScript(() => {
+    (window as unknown as { __enterLog: unknown[] }).__enterLog = [];
+    const log = (window as unknown as { __enterLog: unknown[] }).__enterLog;
+    const t0 = performance.now();
+    const tick = () => {
+      const has = document.documentElement.hasAttribute('data-enter');
+      const rise = document.getAnimations()
+        .filter(a => (a as CSSAnimation).animationName === 'rise');
+      log.push({ t: Math.round(performance.now() - t0), has, n: rise.length,
+        unfinished: rise.filter(a => a.playState !== 'finished').length });
+      if (has || performance.now() - t0 < 3000) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+  await page.goto('/dice', { waitUntil: 'domcontentloaded' });
+  await expect.poll(
+    () => page.evaluate(() => document.documentElement.hasAttribute('data-enter')),
+    { timeout: 6000, message: 'data-enter 一直沒被移除' },
+  ).toBe(false);
+
+  type Frame = { t: number; has: boolean; n: number; unfinished: number };
+  const log = await page.evaluate(
+    () => (window as unknown as { __enterLog: Frame[] }).__enterLog,
+  ) as Frame[];
+  const held = log.filter(f => f.has);
+  // 正向控制：真的取樣到「動畫還掛著」的畫面，而且卡片數是 41——取樣器沒跑或選擇器過期時
+  // 底下那條會是「空陣列的最後一筆」而永遠通過。
+  expect(held.length, '一格都沒取樣到 data-enter 還在的狀態，這條斷言等於沒守')
+    .toBeGreaterThan(3);
+  const last = held[held.length - 1]!;
+  expect(last.n, `取樣到的 rise 動畫只有 ${last.n} 個，不是 41 張卡片`).toBe(41);
+  expect(last.unfinished,
+    `data-enter 在 ${last.t}ms 被拿掉，但那一刻還有 ${last.unfinished} 張卡片的進場動畫沒跑完，`
+    + '它們會直接跳到終點。八成是 Base.astro 沒用 cssMs() 讀長度（壓縮後的 CSS 是 .44s 不是 440ms）')
+    .toBe(0);
+});
+
+test('D17b. 減少動態：進場整組不跑，而且卡片是看得見的', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/dice', { waitUntil: 'domcontentloaded' });
+  const s = await page.locator('.dice-card').nth(20).evaluate(el => {
+    const cs = getComputedStyle(el);
+    return { name: cs.animationName, opacity: cs.opacity };
+  });
+  // 關動畫的寫法若是「長度歸零」而不是 `animation: none`，`both` 仍然成立，帶延遲的卡片會
+  // 停在 opacity: 0，使用者看到的是一頁慢慢補齊的空白格。**攔住那個寫法的是這一條**
+  // （animation-duration: 0s 之下 animationName 仍然是 rise，2026-08-26 反例實跑確認）。
+  expect(s.name, 'reduce 之下進場動畫沒關掉').toBe('none');
+  // 底下這條是結果面的保險，不是上面那條的替代品：它驗的是「使用者真的看得到卡片」。
+  // ⚠️ 老實說今天它抓不到任何上面那條抓不到的東西——opacity: 0 只存在於 keyframes 裡，
+  // 動畫一關就不可能留下。留著是因為「reduce 之下整頁不准是空白」這個性質值得有一條寫死的
+  // 斷言，將來起點若改成寫在元素上（**不要那樣做**，見 base.css 的說明）它就是唯一的防線。
+  expect(s.opacity, 'reduce 之下卡片停在透明').toBe('1');
+});
+
+/**
+ * D18. 按下去要有回饋（2026-08-26 PR ⑥）。這張 PR 之前全站**一條 :active 規則都沒有**，
+ * 手機上從按下去到頁面反應之間完全沒有任何回應。
+ *
+ * ⚠️ 卡片是 `<a>`，在原地放開會觸發 click 導航掉、元素就不見了——所以放開前一定要先把
+ * 游標移開（實測過：不移開的話讀「放開後」那一步會在 locator timeout 掛掉）。
+ */
+test('D18. 按住時縮一下，放開回原狀；reduce 之下整組關掉', async ({ page }) => {
+  const CASES = [
+    { path: '/', selector: '.home-card' },
+    { path: '/dice', selector: '.chip' },
+    { path: '/board', selector: '#board-tools button' },
+    { path: '/tree', selector: '#filters-toggle' },
+    // ⚠️ /sim 一定要列進來：它的 reduce 覆寫 2026-08-26 少了 `:not(:disabled)`，具體度
+    // 輸給正常那條、按壓在 reduce 之下照樣縮，而當時 D18 沒有涵蓋這一頁、D14 涵蓋了卻只
+    // 驗 transition-duration 不驗 transform——兩條加起來還是漏。
+    { path: '/sim', selector: '#sim-toolbar button:not(:disabled)' },
+  ] as const;
+
+  const pressed = async (selector: string) => {
+    const el = page.locator(selector).first();
+    await el.scrollIntoViewIfNeeded();
+    const box = (await el.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    // 等過場跑完再讀：--t-press 是 80ms，按下去立刻讀會讀到中途的 0.99x。
+    await page.waitForTimeout(200);
+    const held = await el.evaluate(n => getComputedStyle(n).transform);
+    await page.mouse.move(2, 2);
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+    return { held, released: await el.evaluate(n => getComputedStyle(n).transform) };
+  };
+
+  const scaleOf = (transform: string) => {
+    const m = transform.match(/^matrix\(([\d.]+),/);
+    return m ? parseFloat(m[1]!) : null;
+  };
+
+  for (const c of CASES) {
+    await page.emulateMedia({ reducedMotion: null });
+    await page.goto(c.path);
+    // ⚠️ 等進場動畫收掉再測：那段期間 animation 的 both 填充會壓過 :active 的 transform。
+    await expect.poll(() => page.evaluate(() => !document.documentElement.hasAttribute('data-enter')),
+      { timeout: 5000 }).toBe(true);
+
+    const normal = await pressed(c.selector);
+    expect.soft(scaleOf(normal.held), `${c.path} 的 ${c.selector} 按住時沒有縮`).toBeLessThan(1);
+    expect.soft(normal.released, `${c.path} 的 ${c.selector} 放開後沒有回原狀`).toBe('none');
+
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto(c.path);
+    const reduced = await pressed(c.selector);
+    expect.soft(reduced.held, `reduce 之下 ${c.path} 的 ${c.selector} 按住時仍然會縮`).toBe('none');
+  }
 });

--- a/tests/e2e/codex.spec.ts
+++ b/tests/e2e/codex.spec.ts
@@ -7,7 +7,7 @@
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import sharp from 'sharp';
-import { resolveColor } from './probe';
+import { resolveColor, settleEnter } from './probe';
 
 const tree = JSON.parse(
   readFileSync(new URL('../../src/generated/tree.json', import.meta.url), 'utf8'),
@@ -72,6 +72,9 @@ test('C3. 卡片裡的 #關鍵字 就地換頁：左右滑動過場、卡片高�
   const term = (await link.getAttribute('data-term'))!;
 
   // 高度是這個設計唯一的硬性要求：41 張卡片排在 CSS grid 裡，任何一張改高度都會推動整列。
+  // ⚠️ 先等進場動畫收掉再量：動畫期間卡片掛著 transform，boundingBox 會帶次像素誤差，
+  // 底下那條嚴格相等會假紅（2026-08-26 實測 368.8124694824219 vs 368.8125）。見 probe.ts。
+  await settleEnter(page);
   const box = (await card.boundingBox())!;
   const before = box.height;
   await expect(stage).toBeHidden();

--- a/tests/e2e/probe.ts
+++ b/tests/e2e/probe.ts
@@ -15,3 +15,19 @@ export async function resolveColor(page: Page, cssVar: string): Promise<string> 
     return c;
   }, cssVar);
 }
+
+/**
+ * 等進場動畫（PR ⑥）跑完再往下量。
+ *
+ * `[data-enter]` 期間卡片掛著 `animation: rise … both`，而**帶 transform 的元素量出來的
+ * boundingBox 會有次像素誤差**——C3 斷言「翻到關鍵字頁前後卡片高度一模一樣」用的是嚴格
+ * 相等，2026-08-26 實測撞到 `368.8124694824219` vs `368.8125` 這種差 3e-5 的假紅。
+ *
+ * ⚠️ 這不是把測試放寬，是把它移到正確的時間點量：動畫進行中的幾何本來就不是這條測試
+ * 要守的東西。凡是在 /dice、/、/guide 上量卡片幾何的測試都該先呼叫它。
+ * ⚠️ 也不要改成「固定等一秒」——長度由 CSS 的 --t-slow／--p-stagger 決定，寫死就是第二份。
+ */
+export async function settleEnter(page: Page): Promise<void> {
+  await page.waitForFunction(() => !document.documentElement.hasAttribute('data-enter'),
+    undefined, { timeout: 5000 });
+}

--- a/tests/lib/css-ms.test.ts
+++ b/tests/lib/css-ms.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { msFromCss } from '../../src/lib/css-ms.js';
+
+describe('msFromCss', () => {
+  it('ms 與 s 兩種單位都認得', () => {
+    expect(msFromCss('440ms', 1)).toBe(440);
+    // ⚠️ 這一條是整支檔案存在的理由：Astro 的 CSS 壓縮把 `440ms` 改寫成 `.44s`，
+    // 裸的 parseFloat 會拿到 0.44。2026-08-26 實際咬到進場動畫（見 src/lib/css-ms.ts）。
+    expect(msFromCss('.44s', 1)).toBe(440);
+    expect(msFromCss('0.28s', 1)).toBe(280);
+    // ⚠️ `440ms` 也是 endsWith('s')，先判 ms 才不會變成 440 秒。
+    expect(msFromCss('80ms', 1)).toBe(80);
+  });
+
+  it('讀不出正數時退回 fallback，不要靜靜地回 NaN 或 0', () => {
+    // 無單位的時間值在 CSS 裡是無效的；讀到它代表變數名打錯或值寫錯。
+    for (const raw of ['', '440', 'auto', '0ms', '-5s', 'var(--x)']) {
+      expect(msFromCss(raw, 7), `${raw} 應該退回 fallback`).toBe(7);
+    }
+  });
+});
+
+/**
+ * 「JS 不寫第二份」這條規則要有東西守著。
+ *
+ * 2026-08-26 之前 `cssMs` 有三份複本（tree-canvas.ts、dice.astro、Base.astro），而**第三份
+ * 漏了 `s` 的分支**——三份都在、三份都看起來對，只有壓縮過的產物會露餡。現在實作收在
+ * `src/lib/css-ms.ts` 一份，這條擋下一次複製。
+ */
+describe('時間類 CSS 變數只有一個解析器', () => {
+  const walk = (dir: string): string[] =>
+    (readdirSync(dir, { recursive: true }) as string[])
+      .map(f => `${dir}/${f.replace(/\\/g, '/')}`)
+      .filter(f => /\.(ts|astro)$/.test(f));
+  const FILES = [...walk('src'), ...walk('tools')]
+    .filter(f => !f.endsWith('src/lib/css-ms.ts'));
+
+  it('沒有第二個地方自己 parseFloat 一個時間變數', () => {
+    const bad: string[] = [];
+    let scanned = 0;
+    for (const file of FILES) {
+      const src = readFileSync(file, 'utf8');
+      scanned++;
+      // 抓「parseFloat(… getPropertyValue(…) …)」這個形狀，跨不跨行都算。
+      for (const m of src.matchAll(/parseFloat\([^;]{0,200}?getPropertyValue\(\s*'(--[a-z0-9-]+)'/gs)) {
+        const name = m[1]!;
+        // --nav-h／--chips-h 是長度不是時間，走不走 cssMs 都一樣；只擋時間類。
+        if (/^--(t-|slide-ms|p-stagger$)/.test(name)) bad.push(`${file} ${name}`);
+      }
+    }
+    expect(scanned, '一個檔都沒掃到——列舉失效了').toBeGreaterThan(20);
+    expect(bad, '這些地方自己解析時間變數，改用 src/lib/css-ms.ts 的 cssMs()').toEqual([]);
+  });
+});

--- a/tests/styles/tokens.test.ts
+++ b/tests/styles/tokens.test.ts
@@ -139,6 +139,11 @@ describe('版面級距', () => {
       '--chips-h', // src/scripts/tree-canvas.ts 量手機版底部分支列高度
       '--sim-panel-h', // src/scripts/sim.ts 量 /sim 手機版抽屜的實際高度（footer 靠它讓位）
       '--branch', // .dice-card[data-branch=…] 自己設，見 components.css 的分支色條
+      // 進場動畫的序號，由 Astro 在建置時寫成每張卡片的 inline style（index.astro／
+      // guide/index.astro／DiceCard.astro）。⚠️ base.css 引用它時**一定要帶預設值**
+      // （`var(--i, 0)`）：漏掉 --i 的卡片會讓整條 animation-delay 變成 invalid，
+      // 那張卡片的 both 填充跟著失效，畫面上是「有一張卡片沒有淡入」——沒有任何東西會報錯。
+      '--i',
     ]);
 
     const missing = new Set<string>();
@@ -172,7 +177,10 @@ describe('版面級距', () => {
     const defined = [...tokens.matchAll(/^\s{2}(--[a-z0-9-]+):\s*([^;]+);/gm)]
       .map(m => ({ name: m[1]!, value: m[2]!.trim() }));
 
-    const LADDERS = ['--r-', '--fs-', '--space-', '--shadow-'];
+    // 2026-08-26 PR ⑥ 補上 --t-（節奏）與 --e-（曲線）：三條曲線撞值等於「兩個名字同一條
+    // 貝茲」，而 --e-spring 與 --e-out 撞在一起時 spec §2 決策 4（spring 只給狀態切換）
+    // 就靜靜失效了，畫面上看起來只是「全部都不回彈」。
+    const LADDERS = ['--r-', '--fs-', '--space-', '--shadow-', '--t-', '--e-'];
     const dupes: string[] = [];
     for (const prefix of LADDERS) {
       const group = defined.filter(t => t.name.startsWith(prefix));
@@ -327,5 +335,97 @@ describe('自架字型（Archivo）', () => {
     // 跟同一句話裡其他中文長得不一樣。
     expect(split(fontNum!).slice(1), '--font-num 後面接的不是 --font 的完整清單，中文會掉到瀏覽器預設')
       .toEqual(split(font!));
+  });
+});
+
+/**
+ * 過場曲線一律走 token（2026-08-26 PR ⑥）。
+ *
+ * PR ⑥ 之前全站的 `transition` 都寫著裸的 `ease`（或整個省略，等於 `ease`）。`ease` 是
+ * 兩端都慢的曲線，在 90–200ms 這種短過場上起步會頓一下；三條 token 曲線各有明確用途
+ * （見 tokens.css 的 --e-out／--e-in-out／--e-spring）。這條擋的是下一次「就這一個地方
+ * 隨手寫個 ease」——那不會壞掉、不會有任何測試說話，只是那一個元件跟全站不同調。
+ */
+describe('過場曲線', () => {
+  it('每一條 transition 都指名 token 曲線，不留裸的 ease', () => {
+    const bad: string[] = [];
+    let seen = 0;
+    for (const file of FILES) {
+      const src = stripComments(readFileSync(file, 'utf8'));
+      // 跨行比對：這個 repo 的多屬性 transition 是一個屬性一行的。
+      for (const m of src.matchAll(/transition:\s*([^;{}]+);/g)) {
+        const value = m[1]!.replace(/\s+/g, ' ').trim();
+        if (value === 'none') continue;
+        seen++;
+        // 一條 transition 可以列很多個屬性，逗號切開之後每一段都要自己指名曲線。
+        for (const part of value.split(',').map(v => v.trim()).filter(Boolean)) {
+          if (!/var\(--(e-[a-z-]+|slide-ease)\)/.test(part)) bad.push(`${file}  ${part}`);
+        }
+      }
+    }
+    // 正向控制：正則過期時 seen 會變 0，底下的斷言就永遠成立。
+    expect(seen, '一條 transition 都沒掃到——正則過期了').toBeGreaterThan(8);
+    expect(bad).toEqual([]);
+  });
+});
+
+/**
+ * 進場動畫的三個常數不准散開（2026-08-26 PR ⑥）。
+ *
+ * 「夾住 stagger 上限」這件事牽到三個地方：CSS 的 `min(var(--i), var(--p-stagger-max))`、
+ * Base.astro 移除 `data-enter` 的 setTimeout、以及 tokens.css 的定義。任何一邊自己寫死
+ * 數字，畫面都還是好的——只有「最後幾張卡片還沒浮出來就被關掉動畫」這種很難察覺的症狀。
+ */
+describe('進場動畫的常數', () => {
+  const BASE_CSS = `${STYLE_DIR}/base.css`;
+  const LAYOUT = 'src/layouts/Base.astro';
+
+  it('stagger 上限只有 tokens.css 一份，CSS 與 Base.astro 都是讀它', () => {
+    const tokens = stripComments(readFileSync(TOKENS_FILE, 'utf8'));
+    expect(tokens, 'tokens.css 沒有定義 --p-stagger-max').toMatch(/^\s{2}--p-stagger-max:/m);
+
+    const base = stripComments(readFileSync(BASE_CSS, 'utf8'));
+    // ⚠️ 不是找「有沒有提到 --p-stagger-max」，是找「延遲有沒有夾」——只寫
+    // `calc(var(--i) * var(--p-stagger))` 一樣會過前一條斷言，但 /dice 最後一張要等 3.64 秒。
+    expect(base, 'base.css 的 animation-delay 沒有夾上限，/dice 第 41 張要等 3.64 秒')
+      .toMatch(/animation-delay:\s*calc\(\s*min\(\s*var\(--i[^)]*\),\s*var\(--p-stagger-max\)\s*\)/);
+
+    // ⚠️ 只比對變數名，不要把讀取函式的名字寫死成 `cssNum(`——2026-08-26 把它換成
+    // src/lib/css-ms.ts 的 cssMs/cssNumber 時這條就紅了，而它其實沒有壞。
+    // 真正要守的是「這兩個值是從 CSS 讀的、不是在 JS 裡寫死數字」，所以比對的形狀是
+    // 「某個函式呼叫帶著這個變數名」。
+    const layout = readFileSync(LAYOUT, 'utf8');
+    for (const name of ['--p-stagger-max', '--t-slow', '--p-stagger']) {
+      expect(layout, `Base.astro 移除 data-enter 的時間沒有從 CSS 讀 ${name}`)
+        .toMatch(new RegExp(`\\w+\\(\\s*'${name}'`));
+    }
+    // ⚠️ 時間類的那兩個一定要走 cssMs()：壓縮後的 CSS 是 `.44s` 不是 `440ms`，裸的
+    // parseFloat 會讀成 0.44（見 src/lib/css-ms.ts 與 E2E 的 D17c）。
+    for (const name of ['--t-slow', '--p-stagger']) {
+      expect(layout, `Base.astro 讀 ${name} 沒有走 cssMs()`).toContain(`cssMs('${name}'`);
+    }
+  });
+
+  it('base.css 引用 --i 一定要帶預設值', () => {
+    // --i 是 inline style 給的，不在 :root。少了預設值時，沒拿到 --i 的元素會讓整條
+    // animation-delay 變成 invalid at computed-value time，`both` 的填充跟著失效——
+    // 畫面上是「有一張卡片沒有淡入」，不報錯、沒有任何測試會說話。
+    const base = stripComments(readFileSync(BASE_CSS, 'utf8'));
+    const refs = [...base.matchAll(/var\(--i([^)]*)\)/g)].map(m => m[1]!.trim());
+    expect(refs.length, 'base.css 沒有引用 --i——進場 stagger 不見了').toBeGreaterThan(0);
+    for (const r of refs) {
+      expect(r, `base.css 有一處 var(--i) 沒帶預設值（寫成 var(--i, 0)）`).toMatch(/^,\s*\d+$/);
+    }
+  });
+
+  it('模板不自己夾 index——夾的動作只在 CSS', () => {
+    // 三個模板寫 --i 的地方各一個。夾在模板裡的話上限就有兩份，而且改 token 不會跟著動。
+    for (const file of ['src/pages/index.astro', 'src/pages/guide/index.astro',
+                        'src/components/DiceCard.astro']) {
+      const src = readFileSync(file, 'utf8');
+      expect(src, `${file} 沒有寫 --i，進場 stagger 會整頁同時浮出`).toContain('--i:');
+      expect(src, `${file} 在模板裡夾了上限——那件事只准在 base.css 的 min() 做`)
+        .not.toMatch(/Math\.min\([^)]*\)/);
+    }
   });
 });


### PR DESCRIPTION
## 做了什麼

十個動效 token 全上（`--t-fast` 120→90、新增 `--t-press/slow`、三條曲線、`--p-press/stagger/stagger-max/glow`），`--slide-ease` 收成 `var(--e-out)`。全站不再有裸的 `ease`。

- **按壓回饋** — 這張 PR 之前全站**一條 `:active` 規則都沒有**。卡片、切換鈕、`/board`／`/tree`／`/sim` 的按鈕、`.card-term-back`；停用的按鈕排除。
- **進場** — `rise` 掛在三種卡片上，`--i` 由 Astro 寫成 inline style，**夾上限的動作只在 CSS**（`min(var(--i,0), var(--p-stagger-max))`），`Base.astro` 的 setTimeout 讀同一個 token。
- **spring 只有兩處**（spec §2 決策 4）：切換鈕被勾選、`/tree` 篩選面板開合。切換鈕上是靠**屬性**分的——`color/border-color` 走 `--e-out`（hover 會改），`background-color/box-shadow` 走 `--e-spring`（只有勾選才會改）。

## 三個實作上非做不可的偏離

1. `:active` 裡**不能**寫 `transition-duration: var(--t-press)`——那是單值，會把同一份清單裡每個屬性的長度一起壓掉，而按下切換鈕時 `:active` 與 `:checked` 同時發生，spring 就在它唯一該出現的互動上被關掉。
2. **reduce 的覆寫選擇器要跟被覆寫那條長得一模一樣，`:is()` 的包法也要一樣。** `:is()` 的具體度等於引數裡最高的那個。
3. `data-enter` 由 `<head>` 裡一支同步 `is:inline` script 掛，不是伺服器端輸出——後者在沒有 JS 的環境會永遠留著。

## code review（high）抓到五條，全部已修

**HIGH：`Base.astro` 用裸的 `parseFloat` 讀 `--t-slow`，進場動畫被腰斬。** Astro 的 CSS 壓縮把 `440ms` 改寫成 **`.44s`**，`parseFloat` 拿到 **0.44**。逐幀取樣實測：`data-enter` 在 **957ms** 被拿掉，那一格 **41 張卡片有 36 張的 `rise` 還沒跑完**，直接跳到終點。**只在建置產物裡發生**，`astro dev` 不壓縮。

修法不是就地補一個 `s` 分支——repo 裡已經有**兩份**逐字相同的正確實作，這是第三份、剛好漏了那個分支。三份全部收進 **`src/lib/css-ms.ts`** 一份。

其餘四條：`/sim` 的 reduce 覆寫少了 `:not(:disabled)`（就是上面第 2 點那個陷阱，唯獨這頁沒做對）；D14 的 hover 正向控制在 `/dice` 上因為 `animation … both` 壓過 `:hover` 而變成空的（刪掉 `.dice-card:hover { transform }` 仍然全綠）；切換鈕光暈 22%→20% 是真的視覺變動已補註；一條過期註解。

## 撞到兩條既有測試，都是真的問題

- **C11**（沒有 JS 時檔位切得動）：`data-enter` 永遠留著 → Playwright 判定元素 not stable，30 秒逾時。
- **C3**（翻頁前後卡片高度一模一樣）：動畫期間卡片掛著 transform，`boundingBox` 帶次像素誤差（`368.8124694824219` vs `368.8125`）。**沒有把斷言放寬**，是加了 `probe.ts` 的 `settleEnter(page)` 把它移到正確的時間點量。

## 新的守門（每條都跑過會紅的反例）

| 測試 | 守什麼 | 反例 |
|---|---|---|
| `css-ms.test.ts` | `.44s` 要讀成 440 | 砍掉 `s` 分支 → 紅 |
| `css-ms.test.ts` | 沒有第二個地方自己 parseFloat 時間變數 | 別處再寫一份 → 紅 |
| `tokens.test.ts` | Base.astro 的三個值都從 CSS 讀、時間類走 `cssMs` | 改成寫死 440 → 紅 |
| `chrome.spec.ts` D17c | `data-enter` 拿掉那一格不准有動畫沒跑完 | 改回 `parseFloat` → 紅（指出 36 張） |
| `chrome.spec.ts` D18 | 按壓 ＋ reduce 關掉（含 `/sim`） | 拿掉 `:not(:disabled)` → 紅 |
| `chrome.spec.ts` D14 | hover 正向控制不准量到動畫填充值 | 刪 `.dice-card:hover` 的 transform → 紅 |

## 已知且刻意接受

載入後約一秒內卡片 hover 不會抬起（`animation-fill-mode: both` 的結束值壓過 `:hover` 的 transform）。

## 本機驗證

`validate` ✅ / `typecheck` ✅ / `test` 621 passed / `e2e` 333 passed